### PR TITLE
Implement `getL1DataCost()` in L1Block

### DIFF
--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -5,6 +5,7 @@ import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { GasPayingToken, IGasToken } from "src/libraries/GasPayingToken.sol";
 import { NotDepositor } from "src/libraries/L1BlockErrors.sol";
+import { TeaWAPOracle } from "./TeaWAPOracle.sol";
 
 /// @custom:proxied true
 /// @custom:predeploy 0x4200000000000000000000000000000000000015
@@ -13,7 +14,7 @@ import { NotDepositor } from "src/libraries/L1BlockErrors.sol";
 ///         Values within this contract are updated once per epoch (every L1 block) and can only be
 ///         set by the "depositor" account, a special system address. Depositor account transactions
 ///         are created by the protocol whenever we move to a new epoch.
-contract L1Block is ISemver, IGasToken {
+contract L1Block is TeaWAPOracle, ISemver, IGasToken {
     /// @notice Event emitted when the gas paying token is set.
     event GasPayingTokenSet(address indexed token, uint8 indexed decimals, bytes32 name, bytes32 symbol);
 
@@ -177,5 +178,68 @@ contract L1Block is ISemver, IGasToken {
         GasPayingToken.set({ _token: _token, _decimals: _decimals, _name: _name, _symbol: _symbol });
 
         emit GasPayingTokenSet({ token: _token, decimals: _decimals, name: _name, symbol: _symbol });
+    }
+
+    /////////////////////////////////
+    /// L1 DATA COST CALCULATIONS ///
+    /////////////////////////////////
+
+    /// @notice The L1 Cost Intercept, defined in the Fjord spec.
+    uint256 public constant L1_COST_INTERCEPT_POSITIVE = 42_585_600;
+
+    /// @notice The L1 Cost FastLZ Coefficient, defined in the Fjord spec.
+    uint256 public constant L1_COST_FASTLZ_COEF = 836_500;
+
+    /// @notice The minimum transaction size, defined in the Fjord spec.
+    uint256 public constant MIN_TRANSACTION_SIZE_SCALED = 100 * 1e6;
+
+    /// @notice A backup TEA/ETH ratio, in the case that the oracle is not set
+    ///         and the fallback price is not set.
+    uint256 public constant BACKUP_TEA_PER_ETH = 1_500_000;
+
+    /// @notice The amount of $TEA required to pay L1 Data Costs for the transaction.
+    /// @param fastLzSize The size of the transaction after FastLZ compression (calculated in op-geth).
+    /// @param isDepositTx Whether the transaction is a deposit transaction.
+    /// @return l1DataCostTEA The amount of $TEA required to pay L1 Data Costs for the transaction.
+    /// @return l1GasUsed An estimate of how much L1 gas was used (used in L2 receipts).
+    /// @dev Called by the execution layer in L1CostFunc.
+    function getL1DataCost(uint256 /* ones */, uint256 /* zeros */, uint256 fastLzSize, bool isDepositTx)
+        external view returns (uint256 l1DataCostTEA, uint256 l1GasUsed)
+    {
+        // Deposit transactions are not included in blobs, so do not pay any L1 Data Cost.
+        if (isDepositTx) return (0, 0);
+
+        // Implement the Fjord calculation to determine the ETH L1 Data Cost.
+        uint256 l1DataCostETH;
+        (l1DataCostETH, l1GasUsed) = _calculateL1DataCostFjord(fastLzSize);
+
+        // Use TeaWAPOracle to adjust the cost from ETH to $TEA.
+        (uint256 nativeTokenPerETH, uint256 oracleDecimals) = _getTEAPerETH();
+        if (nativeTokenPerETH == 0) {
+            nativeTokenPerETH = BACKUP_TEA_PER_ETH;
+            oracleDecimals = 0;
+        }
+
+        l1DataCostTEA = l1DataCostETH * nativeTokenPerETH / (10 ** oracleDecimals);
+    }
+
+    // Implements: https://specs.optimism.io/protocol/fjord/exec-engine.html#fees
+    function _calculateL1DataCostFjord(uint256 fastLzSize) internal view returns (uint256, uint256) {
+        // Fjord L1 cost function:
+		// l1FeeScaled = baseFeeScalar*l1BaseFee*16 + blobFeeScalar*l1BlobBaseFee
+		// estimatedSize = max(minTransactionSize, intercept + fastlzCoef*fastlzSize)
+		// l1Cost = estimatedSize * l1FeeScaled / 1e12
+
+        uint256 cdCostPerByte = baseFeeScalar * basefee * 16;
+        uint256 blobCostPerByte = blobBaseFeeScalar * blobBaseFee;
+        uint256 l1FeeScaled = cdCostPerByte + blobCostPerByte;
+
+        uint256 estimatedSize = (fastLzSize * L1_COST_FASTLZ_COEF) - L1_COST_INTERCEPT_POSITIVE;
+        if (estimatedSize < MIN_TRANSACTION_SIZE_SCALED) estimatedSize = MIN_TRANSACTION_SIZE_SCALED;
+
+        uint256 l1Cost = l1FeeScaled * uint256(estimatedSize) / 1e12;
+        uint256 cdGasUsed = uint256(estimatedSize) * 16 / 1e6;
+
+        return (l1Cost, cdGasUsed);
     }
 }

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Storage } from "src/libraries/Storage.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
+
+// todo: what if this is upgraded? before and after that tx will be different
+// this means option 2
+
+contract TeaWAPOracle {
+    ////////////////////////////////
+    /////// STORAGE & EVENTS ///////
+    ////////////////////////////////
+
+    /// @notice The storage slot that contains data about the TWAP
+    /// @dev  uint80(fallbackPrice) | uint8(fallbackPriceDecimals) | uint8(twapObservations) | address(oracle)
+    bytes32 internal constant CUSTOM_GAS_TOKEN_ORACLE_SLOT = bytes32(uint256(keccak256("opstack.customgastokenoracle")) - 1);
+
+    /// @notice The number of decimals that the oracle's result will be returned in
+    uint256 constant ORACLE_DECIMALS = 18;
+
+    /// @notice Emitted when the oracle configuration is updated
+    event VelodromeConfigUpdated(uint8 twapObservations, address oracle);
+
+    /// @notice Emitted when the fallback price is updated
+    event FallbackPriceUpdated(uint80 price, uint8 decimals);
+
+    ////////////////////////////////
+    ///// ORACLE FUNCTIONALITY /////
+    ////////////////////////////////
+
+    /// @dev If the oracle is not set, we will return fallback price & decimals.
+    ///      If the fallback price is not set, it will override with a backup in L1Block.sol.
+    function _getTEAPerETH() internal view returns (uint256, uint256) {
+        (uint80 fallbackPrice, uint8 fallbackDecimals, uint8 twapObservations, address oracle) = getOracleConfig();
+
+        if (oracle == address(0)) return (fallbackPrice, fallbackDecimals);
+
+        // https://github.com/velodrome-finance/contracts/blob/main/contracts/Pool.sol
+        // quote(address tokenIn, uint256 amountIn, uint256 granularity)
+        (bool success, bytes memory returndata) = oracle.staticcall(
+            abi.encodeWithSignature(
+                "quote(address,uint256,uin256)",
+                Predeploys.WETH, 10 ** ORACLE_DECIMALS, twapObservations
+            )
+        );
+
+        // It will revert if we don't have sufficient data points saved.
+        if (!success || returndata.length < 32) return (fallbackPrice, fallbackDecimals);
+
+        return (abi.decode(returndata, (uint256)), ORACLE_DECIMALS);
+    }
+
+    ////////////////////////////////
+    //////////// ADMIN /////////////
+    ////////////////////////////////
+
+    function setVelodromeConfig(uint8 _twapObservations, address _oracle) external  {
+        // todo: is this the right admin?
+        require(msg.sender == Predeploys.PROXY_ADMIN, "TeaWAPOracle: admin only");
+        require(_oracle != address(0), "VelodromeOracle: zero address");
+        require(_twapObservations > 0, "VelodromeOracle: zero observations");
+
+        (uint80 fallbackPrice, uint8 fallbackDecimals,,) = getOracleConfig();
+        _setOracleConfig(fallbackPrice, fallbackDecimals, _twapObservations, _oracle);
+
+        emit VelodromeConfigUpdated(_twapObservations, _oracle);
+    }
+
+    /// @dev _price = Native Token per ETH (with _decimals of precision)
+    ///      For example, if $TEA is worth 1/10th of ETH, we could represent
+    ///      this as 10 with 0 decimals of precision. If 1 $TEA was worth
+    ///      2 ETH, we would need to set _price = 5 and _decimals = 1.
+    function setFallbackPrice(uint80 _price, uint8 _decimals) external {
+        require(msg.sender == Predeploys.PROXY_ADMIN, "TeaWAPOracle: admin only");
+        require(_price > 0, "VelodromeOracle: zero price");
+
+        (,, uint8 twapObservations, address oracle) = getOracleConfig();
+        _setOracleConfig(_price, _decimals, twapObservations, oracle);
+
+        emit FallbackPriceUpdated(_price, _decimals);
+    }
+
+    ////////////////////////////////
+    ///// STORAGE READ / WRITE /////
+    ////////////////////////////////
+
+    function getOracleConfig() public view returns (uint80, uint8, uint8, address) {
+        uint256 data = Storage.getUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT);
+
+        uint80 fallbackPrice = uint80(data >> 176);
+        uint8 fallbackPriceDecimals = uint8(data >> 168);
+        uint8 twapObservations = uint8(data >> 160);
+        address oracle = address(uint160(data));
+
+        return (fallbackPrice, fallbackPriceDecimals, twapObservations, oracle);
+    }
+
+    function _setOracleConfig(uint80 fallbackPrice, uint8 fallbackDecimals, uint8 twapObservations, address oracle) public {
+        uint256 value = (
+            uint256(fallbackPrice << 176) |
+            uint256(fallbackDecimals << 168) |
+            uint256(twapObservations << 160) |
+            uint256(uint160(oracle))
+        );
+        Storage.setUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT, value);
+    }
+}


### PR DESCRIPTION
This PR matches with [insert from tea-geth] to upgrade the network to calculate L1 Data Costs in $TEA.

Specifically, this PR adapts `L1Block.sol` to:
- implement a `getL1DataCost()` function for the execution layer to call
- performs the Fjord L1 Data Cost calculation to determine the ETH cost
- adds `TeaWAPOracle.sol` (inherited by L1Block.sol) which calls to Velodrome for the time weighted TEA/ETH price

Remaining Todo:
- [ ] Add tests to L1Block.t.sol
- [ ] Insert linked tea-geth PR above