### PR TITLE
Implement `getL1Fee()` on GasPriceOracle

### DIFF
--- a/ops-bedrock/l2-op-geth.Dockerfile
+++ b/ops-bedrock/l2-op-geth.Dockerfile
@@ -1,4 +1,4 @@
-FROM us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:optimism
+FROM my-tea-geth
 
 RUN apk add --no-cache jq
 

--- a/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
+++ b/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
@@ -57,20 +57,18 @@ contract GasPriceOracle is TeaWAPOracle, ISemver {
     /// @return L1 fee that should be paid for the tx
     function getL1Fee(bytes memory _data) external view returns (uint256) {
         if (isFjord) {
-            return convertToTea(_getL1FeeFjord(_data));
+            return convertETHToTea(_getL1FeeFjord(_data));
         } else if (isEcotone) {
-            return convertToTea(_getL1FeeEcotone(_data));
+            return convertETHToTea(_getL1FeeEcotone(_data));
         }
-        return convertToTea(_getL1FeeBedrock(_data));
+        return convertETHToTea(_getL1FeeBedrock(_data));
     }
 
-    function getL1FeeFromRollupData(uint256, uint256, uint256 fastLzSize, bool isDepositTx)
-        external view returns (uint256 l1DataCost, uint256 estimatedGasUsed)
-    {
-        if (isDepositTx) return (0, 0);
-
-        l1DataCost = convertToTea(_fjordL1Cost(fastLzSize));
+    function getL1Fee(uint256 fastLzSize) external view returns (uint256, uint256) {
+        l1DataCost = convertETHToTea(_fjordL1Cost(fastLzSize));
         estimatedGasUsed = _fjordLinearRegression(_fastLzSize) * 16 / 1e6;
+
+        return (l1DataCost, estimatedGasUsed);
     }
 
     /// @notice returns an upper bound for the L1 fee for a given transaction size.
@@ -87,7 +85,7 @@ contract GasPriceOracle is TeaWAPOracle, ISemver {
         // txSize / 255 + 16 is the practical fastlz upper-bound covers %99.99 txs.
         uint256 flzUpperBound = txSize + txSize / 255 + 16;
 
-        return convertToTea(_fjordL1Cost(flzUpperBound));
+        return convertETHToTea(_fjordL1Cost(flzUpperBound));
     }
 
     /// @notice Set chain to be Ecotone chain (callable by depositor account)

--- a/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
+++ b/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
@@ -65,8 +65,8 @@ contract GasPriceOracle is TeaWAPOracle, ISemver {
     }
 
     function getL1Fee(uint256 fastLzSize) external view returns (uint256, uint256) {
-        l1DataCost = convertETHToTea(_fjordL1Cost(fastLzSize));
-        estimatedGasUsed = _fjordLinearRegression(_fastLzSize) * 16 / 1e6;
+        uint256 l1DataCost = convertETHToTea(_fjordL1Cost(fastLzSize));
+        uint256 estimatedGasUsed = _fjordLinearRegression(fastLzSize) * 16 / 1e6;
 
         return (l1DataCost, estimatedGasUsed);
     }

--- a/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
+++ b/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
@@ -9,6 +9,7 @@ import { Constants } from "src/libraries/Constants.sol";
 // Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { IL1Block } from "src/L2/interfaces/IL1Block.sol";
+import { TeaWAPOracle } from "./TeaWAPOracle.sol";
 
 /// @custom:proxied true
 /// @custom:predeploy 0x420000000000000000000000000000000000000F
@@ -24,7 +25,7 @@ import { IL1Block } from "src/L2/interfaces/IL1Block.sol";
 ///         - event OverheadUpdated(uint256 overhead);
 ///         - event ScalarUpdated(uint256 scalar);
 ///         - event DecimalsUpdated(uint256 decimals);
-contract GasPriceOracle is ISemver {
+contract GasPriceOracle is TeaWAPOracle, ISemver {
     /// @notice Number of decimals used in the scalar.
     uint256 public constant DECIMALS = 6;
 
@@ -56,11 +57,20 @@ contract GasPriceOracle is ISemver {
     /// @return L1 fee that should be paid for the tx
     function getL1Fee(bytes memory _data) external view returns (uint256) {
         if (isFjord) {
-            return _getL1FeeFjord(_data);
+            return convertToTea(_getL1FeeFjord(_data));
         } else if (isEcotone) {
-            return _getL1FeeEcotone(_data);
+            return convertToTea(_getL1FeeEcotone(_data));
         }
-        return _getL1FeeBedrock(_data);
+        return convertToTea(_getL1FeeBedrock(_data));
+    }
+
+    function getL1FeeFromRollupData(uint256, uint256, uint256 fastLzSize, bool isDepositTx)
+        external view returns (uint256 l1DataCost, uint256 estimatedGasUsed)
+    {
+        if (isDepositTx) return (0, 0);
+
+        l1DataCost = convertToTea(_fjordL1Cost(fastLzSize));
+        estimatedGasUsed = _fjordLinearRegression(_fastLzSize) * 16 / 1e6;
     }
 
     /// @notice returns an upper bound for the L1 fee for a given transaction size.
@@ -77,7 +87,7 @@ contract GasPriceOracle is ISemver {
         // txSize / 255 + 16 is the practical fastlz upper-bound covers %99.99 txs.
         uint256 flzUpperBound = txSize + txSize / 255 + 16;
 
-        return _fjordL1Cost(flzUpperBound);
+        return convertToTea(_fjordL1Cost(flzUpperBound));
     }
 
     /// @notice Set chain to be Ecotone chain (callable by depositor account)

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -5,6 +5,7 @@ import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { GasPayingToken, IGasToken } from "src/libraries/GasPayingToken.sol";
 import { NotDepositor } from "src/libraries/L1BlockErrors.sol";
+import { TeaWAPOracle } from "./TeaWAPOracle.sol";
 
 /// @custom:proxied true
 /// @custom:predeploy 0x4200000000000000000000000000000000000015
@@ -13,7 +14,7 @@ import { NotDepositor } from "src/libraries/L1BlockErrors.sol";
 ///         Values within this contract are updated once per epoch (every L1 block) and can only be
 ///         set by the "depositor" account, a special system address. Depositor account transactions
 ///         are created by the protocol whenever we move to a new epoch.
-contract L1Block is ISemver, IGasToken {
+contract L1Block is TeaWAPOracle, ISemver, IGasToken {
     /// @notice Event emitted when the gas paying token is set.
     event GasPayingTokenSet(address indexed token, uint8 indexed decimals, bytes32 name, bytes32 symbol);
 
@@ -177,5 +178,68 @@ contract L1Block is ISemver, IGasToken {
         GasPayingToken.set({ _token: _token, _decimals: _decimals, _name: _name, _symbol: _symbol });
 
         emit GasPayingTokenSet({ token: _token, decimals: _decimals, name: _name, symbol: _symbol });
+    }
+
+    /////////////////////////////////
+    /// L1 DATA COST CALCULATIONS ///
+    /////////////////////////////////
+
+    /// @notice The L1 Cost Intercept, defined in the Fjord spec.
+    uint256 public constant L1_COST_INTERCEPT_POSITIVE = 42_585_600;
+
+    /// @notice The L1 Cost FastLZ Coefficient, defined in the Fjord spec.
+    uint256 public constant L1_COST_FASTLZ_COEF = 836_500;
+
+    /// @notice The minimum transaction size, defined in the Fjord spec.
+    uint256 public constant MIN_TRANSACTION_SIZE_SCALED = 100 * 1e6;
+
+    /// @notice A backup TEA/ETH ratio, in the case that the oracle is not set
+    ///         and the fallback price is not set.
+    uint256 public constant BACKUP_TEA_PER_ETH = 1_500_000;
+
+    /// @notice The amount of $TEA required to pay L1 Data Costs for the transaction.
+    /// @param fastLzSize The size of the transaction after FastLZ compression (calculated in op-geth).
+    /// @param isDepositTx Whether the transaction is a deposit transaction.
+    /// @return l1DataCostTEA The amount of $TEA required to pay L1 Data Costs for the transaction.
+    /// @return l1GasUsed An estimate of how much L1 gas was used (used in L2 receipts).
+    /// @dev Called by the execution layer in L1CostFunc.
+    function getL1DataCost(uint256 /* ones */, uint256 /* zeros */, uint256 fastLzSize, bool isDepositTx)
+        external view returns (uint256 l1DataCostTEA, uint256 l1GasUsed)
+    {
+        // Deposit transactions are not included in blobs, so do not pay any L1 Data Cost.
+        if (isDepositTx) return (0, 0);
+
+        // Implement the Fjord calculation to determine the ETH L1 Data Cost.
+        uint256 l1DataCostETH;
+        (l1DataCostETH, l1GasUsed) = _calculateL1DataCostFjord(fastLzSize);
+
+        // Use TeaWAPOracle to adjust the cost from ETH to $TEA.
+        (uint256 nativeTokenPerETH, uint256 oracleDecimals) = _getTEAPerETH();
+        if (nativeTokenPerETH == 0) {
+            nativeTokenPerETH = BACKUP_TEA_PER_ETH;
+            oracleDecimals = 0;
+        }
+
+        l1DataCostTEA = l1DataCostETH * nativeTokenPerETH / (10 ** oracleDecimals);
+    }
+
+    // Implements: https://specs.optimism.io/protocol/fjord/exec-engine.html#fees
+    function _calculateL1DataCostFjord(uint256 fastLzSize) internal view returns (uint256, uint256) {
+        // Fjord L1 cost function:
+		// l1FeeScaled = baseFeeScalar*l1BaseFee*16 + blobFeeScalar*l1BlobBaseFee
+		// estimatedSize = max(minTransactionSize, intercept + fastlzCoef*fastlzSize)
+		// l1Cost = estimatedSize * l1FeeScaled / 1e12
+
+        uint256 cdCostPerByte = baseFeeScalar * basefee * 16;
+        uint256 blobCostPerByte = blobBaseFeeScalar * blobBaseFee;
+        uint256 l1FeeScaled = cdCostPerByte + blobCostPerByte;
+
+        uint256 estimatedSize = (fastLzSize * L1_COST_FASTLZ_COEF) - L1_COST_INTERCEPT_POSITIVE;
+        if (estimatedSize < MIN_TRANSACTION_SIZE_SCALED) estimatedSize = MIN_TRANSACTION_SIZE_SCALED;
+
+        uint256 l1Cost = l1FeeScaled * uint256(estimatedSize) / 1e12;
+        uint256 cdGasUsed = uint256(estimatedSize) * 16 / 1e6;
+
+        return (l1Cost, cdGasUsed);
     }
 }

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -169,7 +169,6 @@ contract L1Block is ISemver, IGasToken {
             sstore(hash.slot, calldataload(100)) // bytes32
             sstore(batcherHash.slot, calldataload(132)) // bytes32
         }
-        _cacheLatestOraclePrice();
     }
 
     /// @notice Sets the gas paying token for the L2 system. Can only be called by the special

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -119,8 +119,6 @@ contract L1Block is ISemver, IGasToken {
         batcherHash = _batcherHash;
         l1FeeOverhead = _l1FeeOverhead;
         l1FeeScalar = _l1FeeScalar;
-
-        _tryCacheLatestOraclePrice();
     }
 
     /// @notice Updates the L1 block values for an Ecotone upgraded chain.
@@ -137,7 +135,6 @@ contract L1Block is ISemver, IGasToken {
     ///   9. _batcherHash        Versioned hash to authenticate batcher by.
     function setL1BlockValuesEcotone() public {
         _setL1BlockValuesEcotone();
-        _tryCacheLatestOraclePrice();
     }
 
     /// @notice Updates the L1 block values for an Ecotone upgraded chain.
@@ -180,9 +177,5 @@ contract L1Block is ISemver, IGasToken {
         GasPayingToken.set({ _token: _token, _decimals: _decimals, _name: _name, _symbol: _symbol });
 
         emit GasPayingTokenSet({ token: _token, decimals: _decimals, name: _name, symbol: _symbol });
-    }
-
-    function _tryCacheLatestOraclePrice() internal {
-        (Predeploys.GAS_PRICE_ORACLE).call(abi.encodeWithSignature("cacheLatestOraclePrice()"));
     }
 }

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -5,7 +5,6 @@ import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { GasPayingToken, IGasToken } from "src/libraries/GasPayingToken.sol";
 import { NotDepositor } from "src/libraries/L1BlockErrors.sol";
-import { TeaWAPOracle } from "./TeaWAPOracle.sol";
 
 /// @custom:proxied true
 /// @custom:predeploy 0x4200000000000000000000000000000000000015
@@ -14,7 +13,7 @@ import { TeaWAPOracle } from "./TeaWAPOracle.sol";
 ///         Values within this contract are updated once per epoch (every L1 block) and can only be
 ///         set by the "depositor" account, a special system address. Depositor account transactions
 ///         are created by the protocol whenever we move to a new epoch.
-contract L1Block is TeaWAPOracle, ISemver, IGasToken {
+contract L1Block is ISemver, IGasToken {
     /// @notice Event emitted when the gas paying token is set.
     event GasPayingTokenSet(address indexed token, uint8 indexed decimals, bytes32 name, bytes32 symbol);
 
@@ -120,6 +119,8 @@ contract L1Block is TeaWAPOracle, ISemver, IGasToken {
         batcherHash = _batcherHash;
         l1FeeOverhead = _l1FeeOverhead;
         l1FeeScalar = _l1FeeScalar;
+
+        _tryCacheLatestOraclePrice();
     }
 
     /// @notice Updates the L1 block values for an Ecotone upgraded chain.
@@ -136,6 +137,7 @@ contract L1Block is TeaWAPOracle, ISemver, IGasToken {
     ///   9. _batcherHash        Versioned hash to authenticate batcher by.
     function setL1BlockValuesEcotone() public {
         _setL1BlockValuesEcotone();
+        _tryCacheLatestOraclePrice();
     }
 
     /// @notice Updates the L1 block values for an Ecotone upgraded chain.
@@ -167,6 +169,7 @@ contract L1Block is TeaWAPOracle, ISemver, IGasToken {
             sstore(hash.slot, calldataload(100)) // bytes32
             sstore(batcherHash.slot, calldataload(132)) // bytes32
         }
+        _cacheLatestOraclePrice();
     }
 
     /// @notice Sets the gas paying token for the L2 system. Can only be called by the special
@@ -180,66 +183,7 @@ contract L1Block is TeaWAPOracle, ISemver, IGasToken {
         emit GasPayingTokenSet({ token: _token, decimals: _decimals, name: _name, symbol: _symbol });
     }
 
-    /////////////////////////////////
-    /// L1 DATA COST CALCULATIONS ///
-    /////////////////////////////////
-
-    /// @notice The L1 Cost Intercept, defined in the Fjord spec.
-    uint256 public constant L1_COST_INTERCEPT_POSITIVE = 42_585_600;
-
-    /// @notice The L1 Cost FastLZ Coefficient, defined in the Fjord spec.
-    uint256 public constant L1_COST_FASTLZ_COEF = 836_500;
-
-    /// @notice The minimum transaction size, defined in the Fjord spec.
-    uint256 public constant MIN_TRANSACTION_SIZE_SCALED = 100 * 1e6;
-
-    /// @notice A backup TEA/ETH ratio, in the case that the oracle is not set
-    ///         and the fallback price is not set.
-    uint256 public constant BACKUP_TEA_PER_ETH = 1_500_000;
-
-    /// @notice The amount of $TEA required to pay L1 Data Costs for the transaction.
-    /// @param fastLzSize The size of the transaction after FastLZ compression (calculated in op-geth).
-    /// @param isDepositTx Whether the transaction is a deposit transaction.
-    /// @return l1DataCostTEA The amount of $TEA required to pay L1 Data Costs for the transaction.
-    /// @return l1GasUsed An estimate of how much L1 gas was used (used in L2 receipts).
-    /// @dev Called by the execution layer in L1CostFunc.
-    function getL1DataCost(uint256 /* ones */, uint256 /* zeros */, uint256 fastLzSize, bool isDepositTx)
-        external view returns (uint256 l1DataCostTEA, uint256 l1GasUsed)
-    {
-        // Deposit transactions are not included in blobs, so do not pay any L1 Data Cost.
-        if (isDepositTx) return (0, 0);
-
-        // Implement the Fjord calculation to determine the ETH L1 Data Cost.
-        uint256 l1DataCostETH;
-        (l1DataCostETH, l1GasUsed) = _calculateL1DataCostFjord(fastLzSize);
-
-        // Use TeaWAPOracle to adjust the cost from ETH to $TEA.
-        (uint256 nativeTokenPerETH, uint256 oracleDecimals) = _getTEAPerETH();
-        if (nativeTokenPerETH == 0) {
-            nativeTokenPerETH = BACKUP_TEA_PER_ETH;
-            oracleDecimals = 0;
-        }
-
-        l1DataCostTEA = l1DataCostETH * nativeTokenPerETH / (10 ** oracleDecimals);
-    }
-
-    // Implements: https://specs.optimism.io/protocol/fjord/exec-engine.html#fees
-    function _calculateL1DataCostFjord(uint256 fastLzSize) internal view returns (uint256, uint256) {
-        // Fjord L1 cost function:
-		// l1FeeScaled = baseFeeScalar*l1BaseFee*16 + blobFeeScalar*l1BlobBaseFee
-		// estimatedSize = max(minTransactionSize, intercept + fastlzCoef*fastlzSize)
-		// l1Cost = estimatedSize * l1FeeScaled / 1e12
-
-        uint256 cdCostPerByte = baseFeeScalar * basefee * 16;
-        uint256 blobCostPerByte = blobBaseFeeScalar * blobBaseFee;
-        uint256 l1FeeScaled = cdCostPerByte + blobCostPerByte;
-
-        uint256 estimatedSize = (fastLzSize * L1_COST_FASTLZ_COEF) - L1_COST_INTERCEPT_POSITIVE;
-        if (estimatedSize < MIN_TRANSACTION_SIZE_SCALED) estimatedSize = MIN_TRANSACTION_SIZE_SCALED;
-
-        uint256 l1Cost = l1FeeScaled * uint256(estimatedSize) / 1e12;
-        uint256 cdGasUsed = uint256(estimatedSize) * 16 / 1e6;
-
-        return (l1Cost, cdGasUsed);
+    function _tryCacheLatestOraclePrice() internal {
+        (Predeploys.GAS_PRICE_ORACLE).call(abi.encodeWithSignature("cacheLatestOraclePrice()"));
     }
 }

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -17,7 +17,7 @@ contract TeaWAPOracle {
     bytes32 internal constant CUSTOM_GAS_TOKEN_ORACLE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.oracle")) - 1);
 
     /// @notice The storage slot that contains the fallback price, set by admin
-    uint256 internal constant FALLBACK_PRICE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.fallbackprice")) - 1);
+    bytes32 internal constant FALLBACK_PRICE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.fallbackprice")) - 1);
 
     /// @notice A backup TEA/ETH ratio, in the case that the oracle is not set
     ///         and the fallback price is not set.
@@ -35,7 +35,7 @@ contract TeaWAPOracle {
 
     /// @notice Convert the inputted amount of ETH (18 decimals) to $TEA
     /// @dev amount (18 decimals) * teaPerETH (18 decimals) / 1e18 = teaAmount (18 decimals)
-    function convertETHToTea(uint256 amount) external view returns (uint256) {
+    function convertETHToTea(uint256 amount) public view returns (uint256) {
         return amount * teaPerETH() / 1e18;
     }
 
@@ -97,7 +97,7 @@ contract TeaWAPOracle {
 
         _setFallbackPrice(_price);
 
-        emit FallbackPriceUpdated(_price, _decimals);
+        emit FallbackPriceUpdated(_price);
     }
 
     ////////////////////////////////
@@ -119,7 +119,7 @@ contract TeaWAPOracle {
     function getOracleConfig() public view returns (uint96, address) {
         uint256 data = Storage.getUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT);
 
-        uint8 twapObservations = uint96(data >> 160);
+        uint96 twapObservations = uint96(data >> 160);
         address oracle = address(uint160(data));
 
         return (twapObservations, oracle);

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -23,6 +23,10 @@ contract TeaWAPOracle {
     ///         and the fallback price is not set.
     uint256 public constant BACKUP_TEA_WEI_PER_ETH = 1_500_000e18;
 
+    /// @notice The minimum WETH balance of the pool needed for the oracle to be valid.
+    /// @dev If the pool has less than this WETH balance, it may be too easy to manipulate.
+    uint256 public constant MIN_WETH_BALANCE = 1e18;
+
     /// @notice Emitted when the oracle configuration is updated
     event OracleConfigUpdated(uint96 twapObservations, address oracle);
 
@@ -52,6 +56,10 @@ contract TeaWAPOracle {
 
         // If there is no oracle set, return the fallback price.
         if (oracle == address(0)) return fallbackPrice;
+
+        // If there is too little WETH in the pool, it may be manipulated.
+        // @todo any reason to use `reserves` from the pool instead?
+        if (IERC20(Predeploys.WETH).balanceOf(oracle) < MIN_WETH_BALANCE) return fallbackPrice;
 
         // Call the oracle to get the time weighted price.
         // https://github.com/velodrome-finance/contracts/blob/main/contracts/Pool.sol

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -13,11 +13,19 @@ contract TeaWAPOracle {
     ////////////////////////////////
 
     /// @notice The storage slot that contains data about the TWAP
-    /// @dev  uint80(fallbackPrice) | uint8(fallbackPriceDecimals) | uint8(twapObservations) | address(oracle)
-    bytes32 internal constant CUSTOM_GAS_TOKEN_ORACLE_SLOT = bytes32(uint256(keccak256("opstack.customgastokenoracle")) - 1);
+    /// @dev  uint96(twapObservations) | address(oracle)
+    bytes32 internal constant CUSTOM_GAS_TOKEN_ORACLE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.oracle")) - 1);
 
-    /// @notice The number of decimals that the oracle's result will be returned in
-    uint256 constant ORACLE_DECIMALS = 18;
+    /// @notice The storage slot that contains the fallback price, set by admin
+    uint256 internal constant FALLBACK_PRICE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.fallbackprice")) - 1);
+
+    /// @notice The storage slot that contains the last known oracle price
+    /// @dev uint128(blockTime) | uint128(price)
+    uint256 internal constant CACHED_ORACLE_PRICE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.cachedprice")) - 1);
+
+    /// @notice A backup TEA/ETH ratio, in the case that the oracle is not set
+    ///         and the fallback price is not set.
+    uint256 public constant BACKUP_TEA_WEI_PER_ETH = 1_500_000e18;
 
     /// @notice Emitted when the oracle configuration is updated
     event VelodromeConfigUpdated(uint8 twapObservations, address oracle);
@@ -25,30 +33,62 @@ contract TeaWAPOracle {
     /// @notice Emitted when the fallback price is updated
     event FallbackPriceUpdated(uint80 price, uint8 decimals);
 
+    /// @notice Emitted when oracle price is cached
+    event OraclePriceCached(uint128 blockTime, uint128 price);
+
     ////////////////////////////////
     ///// ORACLE FUNCTIONALITY /////
     ////////////////////////////////
 
-    /// @dev If the oracle is not set, we will return fallback price & decimals.
-    ///      If the fallback price is not set, it will override with a backup in L1Block.sol.
-    function _getTEAPerETH() internal view returns (uint256, uint256) {
-        (uint80 fallbackPrice, uint8 fallbackDecimals, uint8 twapObservations, address oracle) = getOracleConfig();
+    /// @notice Cache the latest oracle price in storage.
+    /// @dev This price is used by the mempool to estimate L1 Data Costs when it doesn't have
+    ///      access to the EVM.
+    function cacheLatestOraclePrice() external {
+        require(msg.sender == Predeploys.L1_BLOCK_ATTRIBUTES, "TeaWAPOracle: L1Block only");
 
-        if (oracle == address(0)) return (fallbackPrice, fallbackDecimals);
+        uint256 price = _getPrice();
 
+        if (price > 0) {
+            _setCachedOraclePrice(uint128(block.timestamp), uint128(price));
+            emit OraclePriceCached(uint128(block.timestamp), uint128(price));
+        }
+    }
+
+    function convertToTea(uint256 amount) external view returns (uint256) {
+        return amount * _getTeaPerEth() / 1e18;
+    }
+
+    /// @notice Get the price of price of 1 Ether (1e18) in $TEA (18 decimals).
+    /// @dev If the oracle is not set, we will return fallback price (also in 18 decimals).
+    /// @dev If the fallback price is also not set, we will return a hardcoded backup.
+    function _getTeaPerEth() public view returns (uint256) {
+        (uint80 fallbackPrice, uint8 twapObservations, address oracle) = getOracleConfig();
+
+        if (fallbackPrice == 0) fallbackPrice = BACKUP_TEA_WEI_PER_ETH;
+
+        if (oracle == address(0)) return fallbackPrice;
+
+        (bool success, uint256 price) = _getPrice(oracle, twapObservations);
+
+        if (price == 0) return fallbackPrice;
+
+        return price;
+    }
+
+    function _getPrice(address oracle) internal view returns (uint256 price) {
         // https://github.com/velodrome-finance/contracts/blob/main/contracts/Pool.sol
         // quote(address tokenIn, uint256 amountIn, uint256 granularity)
         (bool success, bytes memory returndata) = oracle.staticcall(
             abi.encodeWithSignature(
                 "quote(address,uint256,uin256)",
-                Predeploys.WETH, 10 ** ORACLE_DECIMALS, twapObservations
+                Predeploys.WETH, 1e18, twapObservations
             )
         );
 
         // It will revert if we don't have sufficient data points saved.
-        if (!success || returndata.length < 32) return (fallbackPrice, fallbackDecimals);
+        if (!success || returndata.length < 32) return 0;
 
-        return (abi.decode(returndata, (uint256)), ORACLE_DECIMALS);
+        return abi.decode(returndata, (uint256));
     }
 
     ////////////////////////////////
@@ -85,24 +125,39 @@ contract TeaWAPOracle {
     ///// STORAGE READ / WRITE /////
     ////////////////////////////////
 
-    function getOracleConfig() public view returns (uint80, uint8, uint8, address) {
-        uint256 data = Storage.getUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT);
-
-        uint80 fallbackPrice = uint80(data >> 176);
-        uint8 fallbackPriceDecimals = uint8(data >> 168);
-        uint8 twapObservations = uint8(data >> 160);
-        address oracle = address(uint160(data));
-
-        return (fallbackPrice, fallbackPriceDecimals, twapObservations, oracle);
+    function getFallbackPrice() public view returns (uint256) {
+        return Storage.getUint(FALLBACK_PRICE_SLOT);
     }
 
-    function _setOracleConfig(uint80 fallbackPrice, uint8 fallbackDecimals, uint8 twapObservations, address oracle) public {
-        uint256 value = (
-            uint256(fallbackPrice << 176) |
-            uint256(fallbackDecimals << 168) |
-            uint256(twapObservations << 160) |
-            uint256(uint160(oracle))
-        );
-        Storage.setUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT, value);
+    function _setFallbackPrice(uint256 _price) internal {
+        Storage.setUint(FALLBACK_PRICE_SLOT, _price);
+    }
+
+    function getOracleConfig() public view returns (uint96, address) {
+        uint256 data = Storage.getUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT);
+
+        uint8 twapObservations = uint96(data >> 160);
+        address oracle = address(uint160(data));
+
+        return (twapObservations, oracle);
+    }
+
+    function _setOracleConfig(uint96 _twapObservations, address _oracle) internal {
+        uint256 data = uint256(_twapObservations) << 160 | uint160(_oracle);
+        Storage.setUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT, data);
+    }
+
+    function getCachedOraclePrice() public view returns (uint128, uint128) {
+        uint256 data = Storage.getUint(CACHED_ORACLE_PRICE_SLOT);
+
+        uint128 blockTime = uint128(data >> 128);
+        uint128 price = uint128(data);
+
+        return (blockTime, price);
+    }
+
+    function _setCachedOraclePrice(uint128 _blockTime, uint128 _price) internal {
+        uint256 data = uint256(_blockTime) << 128 | uint128(_price);
+        Storage.setUint(CACHED_ORACLE_PRICE_SLOT, data);
     }
 }

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Storage } from "src/libraries/Storage.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
+
+// todo: what if this is upgraded? before and after that tx will be different
+// this means option 2
+
+contract TeaWAPOracle {
+    ////////////////////////////////
+    /////// STORAGE & EVENTS ///////
+    ////////////////////////////////
+
+    /// @notice The storage slot that contains data about the TWAP
+    /// @dev  uint80(fallbackPrice) | uint8(fallbackPriceDecimals) | uint8(twapObservations) | address(oracle)
+    bytes32 internal constant CUSTOM_GAS_TOKEN_ORACLE_SLOT = bytes32(uint256(keccak256("opstack.customgastokenoracle")) - 1);
+
+    /// @notice The number of decimals that the oracle's result will be returned in
+    uint256 constant ORACLE_DECIMALS = 18;
+
+    /// @notice Emitted when the oracle configuration is updated
+    event VelodromeConfigUpdated(uint8 twapObservations, address oracle);
+
+    /// @notice Emitted when the fallback price is updated
+    event FallbackPriceUpdated(uint80 price, uint8 decimals);
+
+    ////////////////////////////////
+    ///// ORACLE FUNCTIONALITY /////
+    ////////////////////////////////
+
+    /// @dev If the oracle is not set, we will return fallback price & decimals.
+    ///      If the fallback price is not set, it will override with a backup in L1Block.sol.
+    function _getTEAPerETH() internal view returns (uint256, uint256) {
+        (uint80 fallbackPrice, uint8 fallbackDecimals, uint8 twapObservations, address oracle) = getOracleConfig();
+
+        if (oracle == address(0)) return (fallbackPrice, fallbackDecimals);
+
+        // https://github.com/velodrome-finance/contracts/blob/main/contracts/Pool.sol
+        // quote(address tokenIn, uint256 amountIn, uint256 granularity)
+        (bool success, bytes memory returndata) = oracle.staticcall(
+            abi.encodeWithSignature(
+                "quote(address,uint256,uin256)",
+                Predeploys.WETH, 10 ** ORACLE_DECIMALS, twapObservations
+            )
+        );
+
+        // It will revert if we don't have sufficient data points saved.
+        if (!success || returndata.length < 32) return (fallbackPrice, fallbackDecimals);
+
+        return (abi.decode(returndata, (uint256)), ORACLE_DECIMALS);
+    }
+
+    ////////////////////////////////
+    //////////// ADMIN /////////////
+    ////////////////////////////////
+
+    function setVelodromeConfig(uint8 _twapObservations, address _oracle) external  {
+        // todo: is this the right admin?
+        require(msg.sender == Predeploys.PROXY_ADMIN, "TeaWAPOracle: admin only");
+        require(_oracle != address(0), "VelodromeOracle: zero address");
+        require(_twapObservations > 0, "VelodromeOracle: zero observations");
+
+        (uint80 fallbackPrice, uint8 fallbackDecimals,,) = getOracleConfig();
+        _setOracleConfig(fallbackPrice, fallbackDecimals, _twapObservations, _oracle);
+
+        emit VelodromeConfigUpdated(_twapObservations, _oracle);
+    }
+
+    /// @dev _price = Native Token per ETH (with _decimals of precision)
+    ///      For example, if $TEA is worth 1/10th of ETH, we could represent
+    ///      this as 10 with 0 decimals of precision. If 1 $TEA was worth
+    ///      2 ETH, we would need to set _price = 5 and _decimals = 1.
+    function setFallbackPrice(uint80 _price, uint8 _decimals) external {
+        require(msg.sender == Predeploys.PROXY_ADMIN, "TeaWAPOracle: admin only");
+        require(_price > 0, "VelodromeOracle: zero price");
+
+        (,, uint8 twapObservations, address oracle) = getOracleConfig();
+        _setOracleConfig(_price, _decimals, twapObservations, oracle);
+
+        emit FallbackPriceUpdated(_price, _decimals);
+    }
+
+    ////////////////////////////////
+    ///// STORAGE READ / WRITE /////
+    ////////////////////////////////
+
+    function getOracleConfig() public view returns (uint80, uint8, uint8, address) {
+        uint256 data = Storage.getUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT);
+
+        uint80 fallbackPrice = uint80(data >> 176);
+        uint8 fallbackPriceDecimals = uint8(data >> 168);
+        uint8 twapObservations = uint8(data >> 160);
+        address oracle = address(uint160(data));
+
+        return (fallbackPrice, fallbackPriceDecimals, twapObservations, oracle);
+    }
+
+    function _setOracleConfig(uint80 fallbackPrice, uint8 fallbackDecimals, uint8 twapObservations, address oracle) public {
+        uint256 value = (
+            uint256(fallbackPrice << 176) |
+            uint256(fallbackDecimals << 168) |
+            uint256(twapObservations << 160) |
+            uint256(uint160(oracle))
+        );
+        Storage.setUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT, value);
+    }
+}

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -19,63 +19,41 @@ contract TeaWAPOracle {
     /// @notice The storage slot that contains the fallback price, set by admin
     uint256 internal constant FALLBACK_PRICE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.fallbackprice")) - 1);
 
-    /// @notice The storage slot that contains the last known oracle price
-    /// @dev uint128(blockTime) | uint128(price)
-    uint256 internal constant CACHED_ORACLE_PRICE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.cachedprice")) - 1);
-
     /// @notice A backup TEA/ETH ratio, in the case that the oracle is not set
     ///         and the fallback price is not set.
     uint256 public constant BACKUP_TEA_WEI_PER_ETH = 1_500_000e18;
 
     /// @notice Emitted when the oracle configuration is updated
-    event VelodromeConfigUpdated(uint8 twapObservations, address oracle);
+    event OracleConfigUpdated(uint96 twapObservations, address oracle);
 
     /// @notice Emitted when the fallback price is updated
-    event FallbackPriceUpdated(uint80 price, uint8 decimals);
-
-    /// @notice Emitted when oracle price is cached
-    event OraclePriceCached(uint128 blockTime, uint128 price);
+    event FallbackPriceUpdated(uint256 price);
 
     ////////////////////////////////
     ///// ORACLE FUNCTIONALITY /////
     ////////////////////////////////
 
-    /// @notice Cache the latest oracle price in storage.
-    /// @dev This price is used by the mempool to estimate L1 Data Costs when it doesn't have
-    ///      access to the EVM.
-    function cacheLatestOraclePrice() external {
-        require(msg.sender == Predeploys.L1_BLOCK_ATTRIBUTES, "TeaWAPOracle: L1Block only");
-
-        uint256 price = _getPrice();
-
-        if (price > 0) {
-            _setCachedOraclePrice(uint128(block.timestamp), uint128(price));
-            emit OraclePriceCached(uint128(block.timestamp), uint128(price));
-        }
-    }
-
-    function convertToTea(uint256 amount) external view returns (uint256) {
-        return amount * _getTeaPerEth() / 1e18;
+    /// @notice Convert the inputted amount of ETH (18 decimals) to $TEA
+    /// @dev amount (18 decimals) * teaPerETH (18 decimals) / 1e18 = teaAmount (18 decimals)
+    function convertETHToTea(uint256 amount) external view returns (uint256) {
+        return amount * teaPerETH() / 1e18;
     }
 
     /// @notice Get the price of price of 1 Ether (1e18) in $TEA (18 decimals).
     /// @dev If the oracle is not set, we will return fallback price (also in 18 decimals).
     /// @dev If the fallback price is also not set, we will return a hardcoded backup.
-    function _getTeaPerEth() public view returns (uint256) {
-        (uint80 fallbackPrice, uint8 twapObservations, address oracle) = getOracleConfig();
+    function teaPerETH() public view returns (uint256) {
+        // Load oracle config from storage.
+        (uint96 twapObservations, address oracle) = getOracleConfig();
 
+        // Load fallback price from storage. (If it hasn't been set, use hardcoded backup.)
+        uint256 fallbackPrice = getFallbackPrice();
         if (fallbackPrice == 0) fallbackPrice = BACKUP_TEA_WEI_PER_ETH;
 
+        // If there is no oracle set, return the fallback price.
         if (oracle == address(0)) return fallbackPrice;
 
-        (bool success, uint256 price) = _getPrice(oracle, twapObservations);
-
-        if (price == 0) return fallbackPrice;
-
-        return price;
-    }
-
-    function _getPrice(address oracle) internal view returns (uint256 price) {
+        // Call the oracle to get the time weighted price.
         // https://github.com/velodrome-finance/contracts/blob/main/contracts/Pool.sol
         // quote(address tokenIn, uint256 amountIn, uint256 granularity)
         (bool success, bytes memory returndata) = oracle.staticcall(
@@ -85,38 +63,39 @@ contract TeaWAPOracle {
             )
         );
 
+        // Ensure this function doesn't revert.
         // It will revert if we don't have sufficient data points saved.
         if (!success || returndata.length < 32) return 0;
 
-        return abi.decode(returndata, (uint256));
+        // Return the price, or the fallback price if the price is 0.
+        uint256 price = abi.decode(returndata, (uint256));
+        return price > 0 ? price : fallbackPrice;
     }
 
     ////////////////////////////////
     //////////// ADMIN /////////////
     ////////////////////////////////
 
-    function setVelodromeConfig(uint8 _twapObservations, address _oracle) external  {
+    /// @param _twapObservations Number of observations to ask from the oracle
+    /// @param _oracle Address of the oracle contract to use
+    function setOracleConfig(uint96 _twapObservations, address _oracle) external  {
         // todo: is this the right admin?
         require(msg.sender == Predeploys.PROXY_ADMIN, "TeaWAPOracle: admin only");
         require(_oracle != address(0), "VelodromeOracle: zero address");
         require(_twapObservations > 0, "VelodromeOracle: zero observations");
 
-        (uint80 fallbackPrice, uint8 fallbackDecimals,,) = getOracleConfig();
-        _setOracleConfig(fallbackPrice, fallbackDecimals, _twapObservations, _oracle);
+        _setOracleConfig(_twapObservations, _oracle);
 
-        emit VelodromeConfigUpdated(_twapObservations, _oracle);
+        emit OracleConfigUpdated(_twapObservations, _oracle);
     }
 
-    /// @dev _price = Native Token per ETH (with _decimals of precision)
-    ///      For example, if $TEA is worth 1/10th of ETH, we could represent
-    ///      this as 10 with 0 decimals of precision. If 1 $TEA was worth
-    ///      2 ETH, we would need to set _price = 5 and _decimals = 1.
-    function setFallbackPrice(uint80 _price, uint8 _decimals) external {
+    /// @param _price Fallback price to use if oracle fails
+    /// @dev Price should be set in wei of $TEA per 18 decimals of ETH
+    function setFallbackPrice(uint256 _price) external {
         require(msg.sender == Predeploys.PROXY_ADMIN, "TeaWAPOracle: admin only");
         require(_price > 0, "VelodromeOracle: zero price");
 
-        (,, uint8 twapObservations, address oracle) = getOracleConfig();
-        _setOracleConfig(_price, _decimals, twapObservations, oracle);
+        _setFallbackPrice(_price);
 
         emit FallbackPriceUpdated(_price, _decimals);
     }
@@ -125,6 +104,8 @@ contract TeaWAPOracle {
     ///// STORAGE READ / WRITE /////
     ////////////////////////////////
 
+    /// @return The fallback price to use if the oracle fails
+    /// @dev Price is in wei of $TEA per 18 decimals of ETH
     function getFallbackPrice() public view returns (uint256) {
         return Storage.getUint(FALLBACK_PRICE_SLOT);
     }
@@ -133,6 +114,8 @@ contract TeaWAPOracle {
         Storage.setUint(FALLBACK_PRICE_SLOT, _price);
     }
 
+    /// @return twapObservations The number of TWAP observations to use with the oracle
+    /// @return oracle The address of the oracle contract that is being used
     function getOracleConfig() public view returns (uint96, address) {
         uint256 data = Storage.getUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT);
 
@@ -145,19 +128,5 @@ contract TeaWAPOracle {
     function _setOracleConfig(uint96 _twapObservations, address _oracle) internal {
         uint256 data = uint256(_twapObservations) << 160 | uint160(_oracle);
         Storage.setUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT, data);
-    }
-
-    function getCachedOraclePrice() public view returns (uint128, uint128) {
-        uint256 data = Storage.getUint(CACHED_ORACLE_PRICE_SLOT);
-
-        uint128 blockTime = uint128(data >> 128);
-        uint128 price = uint128(data);
-
-        return (blockTime, price);
-    }
-
-    function _setCachedOraclePrice(uint128 _blockTime, uint128 _price) internal {
-        uint256 data = uint256(_blockTime) << 128 | uint128(_price);
-        Storage.setUint(CACHED_ORACLE_PRICE_SLOT, data);
     }
 }

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.15;
 
 import { Storage } from "src/libraries/Storage.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 // todo: what if this is upgraded? before and after that tx will be different
 // this means option 2

--- a/packages/contracts-bedrock/test/L2/L1Block.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Block.t.sol
@@ -202,17 +202,3 @@ contract L1BlockCustomGasToken_Test is L1BlockTest {
         l1Block.setGasPayingToken(address(this), 18, "Test", "TST");
     }
 }
-
-contract L1BlockGetL1DataCost is L1BlockTest {
-    // deposit tx returns 0s
-
-    // zero fastLzSize returns minimum (no fallback)
-
-    // zero fastLzSize returns minimum (with fallback)
-
-    // zero fastLzSize returns minimum (with oracle, maybe OP Mainnet fork?)
-
-    // one example of larger fastLzSize working as expected
-
-    // changing scalarys and base fees changes appropriately (fuzz?)
-}

--- a/packages/contracts-bedrock/test/L2/L1Block.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Block.t.sol
@@ -202,3 +202,17 @@ contract L1BlockCustomGasToken_Test is L1BlockTest {
         l1Block.setGasPayingToken(address(this), 18, "Test", "TST");
     }
 }
+
+contract L1BlockGetL1DataCost is L1BlockTest {
+    // deposit tx returns 0s
+
+    // zero fastLzSize returns minimum (no fallback)
+
+    // zero fastLzSize returns minimum (with fallback)
+
+    // zero fastLzSize returns minimum (with oracle, maybe OP Mainnet fork?)
+
+    // one example of larger fastLzSize working as expected
+
+    // changing scalarys and base fees changes appropriately (fuzz?)
+}

--- a/setup-devnet.sh
+++ b/setup-devnet.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+stop=$1
+
+if [ -n "$stop" ]; then
+  # https://github.com/moby/moby/issues/36196
+  make devnet-down \
+    && make devnet-clean \
+    && docker image rm $(docker image ls --filter "reference=us-docker.pkg.dev/oplabs-tools-artifacts/images/*:devnet" -q) \
+    && docker volume rm $(docker volume ls -q)
+else
+  # Set memory limits for Python process
+  export NODE_OPTIONS="--max-old-space-size=8192"
+
+  docker build -t my-tea-geth ../tea-geth \
+    && make devnet-up \
+    && docker logs -f ops-bedrock-l2-1
+fi


### PR DESCRIPTION
This PR matches with [tea-geth/pull/4](https://github.com/teaxyz/tea-geth/pull/4) to upgrade the network to calculate L1 Data Costs in $TEA.

Specifically, this PR adapts `GasPriceOracle.sol` to:
- implement a `getL1Fee(uint256)` function for the execution layer to call with the fastLzSize
- adds `TeaWAPOracle.sol` (inherited by L1Block.sol) which calls to Velodrome for the time weighted TEA/ETH price

Remaining Todo:
- [ ] Add tests to GasPriceOracle.t.sol