### PR TITLE
Cache $TEA/ETH exchange rate on GasPriceOracle

### DIFF
--- a/ops-bedrock/l2-op-geth.Dockerfile
+++ b/ops-bedrock/l2-op-geth.Dockerfile
@@ -1,4 +1,4 @@
-FROM us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:optimism
+FROM my-tea-geth
 
 RUN apk add --no-cache jq
 

--- a/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
+++ b/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
@@ -57,20 +57,18 @@ contract GasPriceOracle is TeaWAPOracle, ISemver {
     /// @return L1 fee that should be paid for the tx
     function getL1Fee(bytes memory _data) external view returns (uint256) {
         if (isFjord) {
-            return convertToTea(_getL1FeeFjord(_data));
+            return convertETHToTea(_getL1FeeFjord(_data));
         } else if (isEcotone) {
-            return convertToTea(_getL1FeeEcotone(_data));
+            return convertETHToTea(_getL1FeeEcotone(_data));
         }
-        return convertToTea(_getL1FeeBedrock(_data));
+        return convertETHToTea(_getL1FeeBedrock(_data));
     }
 
-    function getL1FeeFromRollupData(uint256, uint256, uint256 fastLzSize, bool isDepositTx)
-        external view returns (uint256 l1DataCost, uint256 estimatedGasUsed)
-    {
-        if (isDepositTx) return (0, 0);
-
-        l1DataCost = convertToTea(_fjordL1Cost(fastLzSize));
+    function getL1Fee(uint256 fastLzSize) external view returns (uint256, uint256) {
+        l1DataCost = convertETHToTea(_fjordL1Cost(fastLzSize));
         estimatedGasUsed = _fjordLinearRegression(_fastLzSize) * 16 / 1e6;
+
+        return (l1DataCost, estimatedGasUsed);
     }
 
     /// @notice returns an upper bound for the L1 fee for a given transaction size.
@@ -87,7 +85,7 @@ contract GasPriceOracle is TeaWAPOracle, ISemver {
         // txSize / 255 + 16 is the practical fastlz upper-bound covers %99.99 txs.
         uint256 flzUpperBound = txSize + txSize / 255 + 16;
 
-        return convertToTea(_fjordL1Cost(flzUpperBound));
+        return convertETHToTea(_fjordL1Cost(flzUpperBound));
     }
 
     /// @notice Set chain to be Ecotone chain (callable by depositor account)

--- a/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
+++ b/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
@@ -65,8 +65,8 @@ contract GasPriceOracle is TeaWAPOracle, ISemver {
     }
 
     function getL1Fee(uint256 fastLzSize) external view returns (uint256, uint256) {
-        l1DataCost = convertETHToTea(_fjordL1Cost(fastLzSize));
-        estimatedGasUsed = _fjordLinearRegression(_fastLzSize) * 16 / 1e6;
+        uint256 l1DataCost = convertETHToTea(_fjordL1Cost(fastLzSize));
+        uint256 estimatedGasUsed = _fjordLinearRegression(fastLzSize) * 16 / 1e6;
 
         return (l1DataCost, estimatedGasUsed);
     }

--- a/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
+++ b/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
@@ -9,6 +9,7 @@ import { Constants } from "src/libraries/Constants.sol";
 // Interfaces
 import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { IL1Block } from "src/L2/interfaces/IL1Block.sol";
+import { TeaWAPOracle } from "./TeaWAPOracle.sol";
 
 /// @custom:proxied true
 /// @custom:predeploy 0x420000000000000000000000000000000000000F
@@ -24,7 +25,7 @@ import { IL1Block } from "src/L2/interfaces/IL1Block.sol";
 ///         - event OverheadUpdated(uint256 overhead);
 ///         - event ScalarUpdated(uint256 scalar);
 ///         - event DecimalsUpdated(uint256 decimals);
-contract GasPriceOracle is ISemver {
+contract GasPriceOracle is TeaWAPOracle, ISemver {
     /// @notice Number of decimals used in the scalar.
     uint256 public constant DECIMALS = 6;
 
@@ -56,11 +57,20 @@ contract GasPriceOracle is ISemver {
     /// @return L1 fee that should be paid for the tx
     function getL1Fee(bytes memory _data) external view returns (uint256) {
         if (isFjord) {
-            return _getL1FeeFjord(_data);
+            return convertToTea(_getL1FeeFjord(_data));
         } else if (isEcotone) {
-            return _getL1FeeEcotone(_data);
+            return convertToTea(_getL1FeeEcotone(_data));
         }
-        return _getL1FeeBedrock(_data);
+        return convertToTea(_getL1FeeBedrock(_data));
+    }
+
+    function getL1FeeFromRollupData(uint256, uint256, uint256 fastLzSize, bool isDepositTx)
+        external view returns (uint256 l1DataCost, uint256 estimatedGasUsed)
+    {
+        if (isDepositTx) return (0, 0);
+
+        l1DataCost = convertToTea(_fjordL1Cost(fastLzSize));
+        estimatedGasUsed = _fjordLinearRegression(_fastLzSize) * 16 / 1e6;
     }
 
     /// @notice returns an upper bound for the L1 fee for a given transaction size.
@@ -77,7 +87,7 @@ contract GasPriceOracle is ISemver {
         // txSize / 255 + 16 is the practical fastlz upper-bound covers %99.99 txs.
         uint256 flzUpperBound = txSize + txSize / 255 + 16;
 
-        return _fjordL1Cost(flzUpperBound);
+        return convertToTea(_fjordL1Cost(flzUpperBound));
     }
 
     /// @notice Set chain to be Ecotone chain (callable by depositor account)

--- a/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
+++ b/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
@@ -45,6 +45,13 @@ contract GasPriceOracle is TeaWAPOracle, ISemver {
     ///         are set to this value.
     uint256 private constant MIN_TRANSACTION_SIZE = 100;
 
+    /// @notice Event emitted when
+
+    /// @notice Event emitted if the oracle fails.
+    /// @dev This can be used by an off chain watcher to notify the team to
+    ///      investigate the oracle and ensure the fallback price is accurate.
+    event OracleReturnedFallbackPrice();
+
     /// @notice Indicates whether the network has gone through the Ecotone upgrade.
     bool public isEcotone;
 
@@ -64,11 +71,30 @@ contract GasPriceOracle is TeaWAPOracle, ISemver {
         return convertETHToTea(_getL1FeeBedrock(_data));
     }
 
-    function getL1Fee(uint256 fastLzSize) external view returns (uint256, uint256) {
-        uint256 l1DataCost = convertETHToTea(_fjordL1Cost(fastLzSize));
-        uint256 estimatedGasUsed = _fjordLinearRegression(fastLzSize) * 16 / 1e6;
+    /// @notice Pulls the latest price from the oracle and updates the ratio storage slot.
+    /// @dev This function CAN NOT revert, as it is called by the System TX when updating L1Block.sol.
+    function updateGasTokenPriceRatio() external {
+        require(msg.sender == Predeploys.L1_BLOCK_ATTRIBUTES, "GasPriceOracle: only L1_BLOCK_ATTRIBUTES can update");
 
-        return (l1DataCost, estimatedGasUsed);
+        // The oracle calculates the current price of 1e18 ETH in TEA (18 decimals).
+        uint160 currentPrice = teaPerETH();
+
+        // If the call didn't return the fallback price, it succeeded.
+        if (currentPrice != getFallbackPrice()) {
+            _setLatestPrice(currentPrice);
+        } else {
+            // If the call returned the fallback price, it failed.
+            emit OracleReturnedFallbackPrice();
+
+            // If the last result is from within the past 1 hour, keep it.
+            // Otherwise, replace it with currentPrice (fallback)
+            (uint96 lastUpdate, uint160 lastPrice) = getLatestPrice();
+            if (currentPrice != lastPrice) {
+                if (block.timestamp >= lastUpdate + MAX_ORACLE_DOWNTIME) {
+                    _setLatestPrice(currentPrice);
+                }
+            }
+        }
     }
 
     /// @notice returns an upper bound for the L1 fee for a given transaction size.

--- a/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
+++ b/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
@@ -63,12 +63,13 @@ contract GasPriceOracle is TeaWAPOracle, ISemver {
     /// @param _data Unsigned fully RLP-encoded transaction to get the L1 fee for.
     /// @return L1 fee that should be paid for the tx
     function getL1Fee(bytes memory _data) external view returns (uint256) {
+        (, uint160 latestPrice) = getLatestPrice();
         if (isFjord) {
-            return convertETHToTea(_getL1FeeFjord(_data));
+            return latestPrice * _getL1FeeFjord(_data) / 1e18;
         } else if (isEcotone) {
-            return convertETHToTea(_getL1FeeEcotone(_data));
+            return latestPrice * _getL1FeeEcotone(_data) / 1e18;
         }
-        return convertETHToTea(_getL1FeeBedrock(_data));
+        return latestPrice * _getL1FeeBedrock(_data) / 1e18;
     }
 
     /// @notice Pulls the latest price from the oracle and updates the ratio storage slot.
@@ -111,7 +112,8 @@ contract GasPriceOracle is TeaWAPOracle, ISemver {
         // txSize / 255 + 16 is the practical fastlz upper-bound covers %99.99 txs.
         uint256 flzUpperBound = txSize + txSize / 255 + 16;
 
-        return convertETHToTea(_fjordL1Cost(flzUpperBound));
+        (, uint160 latestPrice) = getLatestPrice();
+        return latestPrice * _fjordL1Cost(flzUpperBound) / 1e18;
     }
 
     /// @notice Set chain to be Ecotone chain (callable by depositor account)

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -5,6 +5,7 @@ import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { GasPayingToken, IGasToken } from "src/libraries/GasPayingToken.sol";
 import { NotDepositor } from "src/libraries/L1BlockErrors.sol";
+import { TeaWAPOracle } from "./TeaWAPOracle.sol";
 
 /// @custom:proxied true
 /// @custom:predeploy 0x4200000000000000000000000000000000000015
@@ -13,7 +14,7 @@ import { NotDepositor } from "src/libraries/L1BlockErrors.sol";
 ///         Values within this contract are updated once per epoch (every L1 block) and can only be
 ///         set by the "depositor" account, a special system address. Depositor account transactions
 ///         are created by the protocol whenever we move to a new epoch.
-contract L1Block is ISemver, IGasToken {
+contract L1Block is TeaWAPOracle, ISemver, IGasToken {
     /// @notice Event emitted when the gas paying token is set.
     event GasPayingTokenSet(address indexed token, uint8 indexed decimals, bytes32 name, bytes32 symbol);
 
@@ -177,5 +178,68 @@ contract L1Block is ISemver, IGasToken {
         GasPayingToken.set({ _token: _token, _decimals: _decimals, _name: _name, _symbol: _symbol });
 
         emit GasPayingTokenSet({ token: _token, decimals: _decimals, name: _name, symbol: _symbol });
+    }
+
+    /////////////////////////////////
+    /// L1 DATA COST CALCULATIONS ///
+    /////////////////////////////////
+
+    /// @notice The L1 Cost Intercept, defined in the Fjord spec.
+    uint256 public constant L1_COST_INTERCEPT_POSITIVE = 42_585_600;
+
+    /// @notice The L1 Cost FastLZ Coefficient, defined in the Fjord spec.
+    uint256 public constant L1_COST_FASTLZ_COEF = 836_500;
+
+    /// @notice The minimum transaction size, defined in the Fjord spec.
+    uint256 public constant MIN_TRANSACTION_SIZE_SCALED = 100 * 1e6;
+
+    /// @notice A backup TEA/ETH ratio, in the case that the oracle is not set
+    ///         and the fallback price is not set.
+    uint256 public constant BACKUP_TEA_PER_ETH = 1_500_000;
+
+    /// @notice The amount of $TEA required to pay L1 Data Costs for the transaction.
+    /// @param fastLzSize The size of the transaction after FastLZ compression (calculated in op-geth).
+    /// @param isDepositTx Whether the transaction is a deposit transaction.
+    /// @return l1DataCostTEA The amount of $TEA required to pay L1 Data Costs for the transaction.
+    /// @return l1GasUsed An estimate of how much L1 gas was used (used in L2 receipts).
+    /// @dev Called by the execution layer in L1CostFunc.
+    function getL1DataCost(uint256 /* ones */, uint256 /* zeros */, uint256 fastLzSize, bool isDepositTx)
+        external view returns (uint256 l1DataCostTEA, uint256 l1GasUsed)
+    {
+        // Deposit transactions are not included in blobs, so do not pay any L1 Data Cost.
+        if (isDepositTx) return (0, 0);
+
+        // Implement the Fjord calculation to determine the ETH L1 Data Cost.
+        uint256 l1DataCostETH;
+        (l1DataCostETH, l1GasUsed) = _calculateL1DataCostFjord(fastLzSize);
+
+        // Use TeaWAPOracle to adjust the cost from ETH to $TEA.
+        (uint256 nativeTokenPerETH, uint256 oracleDecimals) = _getTEAPerETH();
+        if (nativeTokenPerETH == 0) {
+            nativeTokenPerETH = BACKUP_TEA_PER_ETH;
+            oracleDecimals = 0;
+        }
+
+        l1DataCostTEA = l1DataCostETH * nativeTokenPerETH / (10 ** oracleDecimals);
+    }
+
+    // Implements: https://specs.optimism.io/protocol/fjord/exec-engine.html#fees
+    function _calculateL1DataCostFjord(uint256 fastLzSize) internal view returns (uint256, uint256) {
+        // Fjord L1 cost function:
+		// l1FeeScaled = baseFeeScalar*l1BaseFee*16 + blobFeeScalar*l1BlobBaseFee
+		// estimatedSize = max(minTransactionSize, intercept + fastlzCoef*fastlzSize)
+		// l1Cost = estimatedSize * l1FeeScaled / 1e12
+
+        uint256 cdCostPerByte = baseFeeScalar * basefee * 16;
+        uint256 blobCostPerByte = blobBaseFeeScalar * blobBaseFee;
+        uint256 l1FeeScaled = cdCostPerByte + blobCostPerByte;
+
+        uint256 estimatedSize = (fastLzSize * L1_COST_FASTLZ_COEF) - L1_COST_INTERCEPT_POSITIVE;
+        if (estimatedSize < MIN_TRANSACTION_SIZE_SCALED) estimatedSize = MIN_TRANSACTION_SIZE_SCALED;
+
+        uint256 l1Cost = l1FeeScaled * uint256(estimatedSize) / 1e12;
+        uint256 cdGasUsed = uint256(estimatedSize) * 16 / 1e6;
+
+        return (l1Cost, cdGasUsed);
     }
 }

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -5,6 +5,8 @@ import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { GasPayingToken, IGasToken } from "src/libraries/GasPayingToken.sol";
 import { NotDepositor } from "src/libraries/L1BlockErrors.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
+import { GasPriceOracle } from "./GasPriceOracle.sol";
 
 /// @custom:proxied true
 /// @custom:predeploy 0x4200000000000000000000000000000000000015
@@ -119,6 +121,9 @@ contract L1Block is ISemver, IGasToken {
         batcherHash = _batcherHash;
         l1FeeOverhead = _l1FeeOverhead;
         l1FeeScalar = _l1FeeScalar;
+
+        // This call must never revert.
+        GasPriceOracle(Predeploys.GAS_PRICE_ORACLE).updateGasTokenPriceRatio();
     }
 
     /// @notice Updates the L1 block values for an Ecotone upgraded chain.
@@ -135,6 +140,9 @@ contract L1Block is ISemver, IGasToken {
     ///   9. _batcherHash        Versioned hash to authenticate batcher by.
     function setL1BlockValuesEcotone() public {
         _setL1BlockValuesEcotone();
+
+        // This call must never revert.
+        GasPriceOracle(Predeploys.GAS_PRICE_ORACLE).updateGasTokenPriceRatio();
     }
 
     /// @notice Updates the L1 block values for an Ecotone upgraded chain.

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -169,7 +169,6 @@ contract L1Block is ISemver, IGasToken {
             sstore(hash.slot, calldataload(100)) // bytes32
             sstore(batcherHash.slot, calldataload(132)) // bytes32
         }
-        _cacheLatestOraclePrice();
     }
 
     /// @notice Sets the gas paying token for the L2 system. Can only be called by the special

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -119,8 +119,6 @@ contract L1Block is ISemver, IGasToken {
         batcherHash = _batcherHash;
         l1FeeOverhead = _l1FeeOverhead;
         l1FeeScalar = _l1FeeScalar;
-
-        _tryCacheLatestOraclePrice();
     }
 
     /// @notice Updates the L1 block values for an Ecotone upgraded chain.
@@ -137,7 +135,6 @@ contract L1Block is ISemver, IGasToken {
     ///   9. _batcherHash        Versioned hash to authenticate batcher by.
     function setL1BlockValuesEcotone() public {
         _setL1BlockValuesEcotone();
-        _tryCacheLatestOraclePrice();
     }
 
     /// @notice Updates the L1 block values for an Ecotone upgraded chain.
@@ -180,9 +177,5 @@ contract L1Block is ISemver, IGasToken {
         GasPayingToken.set({ _token: _token, _decimals: _decimals, _name: _name, _symbol: _symbol });
 
         emit GasPayingTokenSet({ token: _token, decimals: _decimals, name: _name, symbol: _symbol });
-    }
-
-    function _tryCacheLatestOraclePrice() internal {
-        (Predeploys.GAS_PRICE_ORACLE).call(abi.encodeWithSignature("cacheLatestOraclePrice()"));
     }
 }

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -5,7 +5,6 @@ import { ISemver } from "src/universal/interfaces/ISemver.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { GasPayingToken, IGasToken } from "src/libraries/GasPayingToken.sol";
 import { NotDepositor } from "src/libraries/L1BlockErrors.sol";
-import { TeaWAPOracle } from "./TeaWAPOracle.sol";
 
 /// @custom:proxied true
 /// @custom:predeploy 0x4200000000000000000000000000000000000015
@@ -14,7 +13,7 @@ import { TeaWAPOracle } from "./TeaWAPOracle.sol";
 ///         Values within this contract are updated once per epoch (every L1 block) and can only be
 ///         set by the "depositor" account, a special system address. Depositor account transactions
 ///         are created by the protocol whenever we move to a new epoch.
-contract L1Block is TeaWAPOracle, ISemver, IGasToken {
+contract L1Block is ISemver, IGasToken {
     /// @notice Event emitted when the gas paying token is set.
     event GasPayingTokenSet(address indexed token, uint8 indexed decimals, bytes32 name, bytes32 symbol);
 
@@ -120,6 +119,8 @@ contract L1Block is TeaWAPOracle, ISemver, IGasToken {
         batcherHash = _batcherHash;
         l1FeeOverhead = _l1FeeOverhead;
         l1FeeScalar = _l1FeeScalar;
+
+        _tryCacheLatestOraclePrice();
     }
 
     /// @notice Updates the L1 block values for an Ecotone upgraded chain.
@@ -136,6 +137,7 @@ contract L1Block is TeaWAPOracle, ISemver, IGasToken {
     ///   9. _batcherHash        Versioned hash to authenticate batcher by.
     function setL1BlockValuesEcotone() public {
         _setL1BlockValuesEcotone();
+        _tryCacheLatestOraclePrice();
     }
 
     /// @notice Updates the L1 block values for an Ecotone upgraded chain.
@@ -167,6 +169,7 @@ contract L1Block is TeaWAPOracle, ISemver, IGasToken {
             sstore(hash.slot, calldataload(100)) // bytes32
             sstore(batcherHash.slot, calldataload(132)) // bytes32
         }
+        _cacheLatestOraclePrice();
     }
 
     /// @notice Sets the gas paying token for the L2 system. Can only be called by the special
@@ -180,66 +183,7 @@ contract L1Block is TeaWAPOracle, ISemver, IGasToken {
         emit GasPayingTokenSet({ token: _token, decimals: _decimals, name: _name, symbol: _symbol });
     }
 
-    /////////////////////////////////
-    /// L1 DATA COST CALCULATIONS ///
-    /////////////////////////////////
-
-    /// @notice The L1 Cost Intercept, defined in the Fjord spec.
-    uint256 public constant L1_COST_INTERCEPT_POSITIVE = 42_585_600;
-
-    /// @notice The L1 Cost FastLZ Coefficient, defined in the Fjord spec.
-    uint256 public constant L1_COST_FASTLZ_COEF = 836_500;
-
-    /// @notice The minimum transaction size, defined in the Fjord spec.
-    uint256 public constant MIN_TRANSACTION_SIZE_SCALED = 100 * 1e6;
-
-    /// @notice A backup TEA/ETH ratio, in the case that the oracle is not set
-    ///         and the fallback price is not set.
-    uint256 public constant BACKUP_TEA_PER_ETH = 1_500_000;
-
-    /// @notice The amount of $TEA required to pay L1 Data Costs for the transaction.
-    /// @param fastLzSize The size of the transaction after FastLZ compression (calculated in op-geth).
-    /// @param isDepositTx Whether the transaction is a deposit transaction.
-    /// @return l1DataCostTEA The amount of $TEA required to pay L1 Data Costs for the transaction.
-    /// @return l1GasUsed An estimate of how much L1 gas was used (used in L2 receipts).
-    /// @dev Called by the execution layer in L1CostFunc.
-    function getL1DataCost(uint256 /* ones */, uint256 /* zeros */, uint256 fastLzSize, bool isDepositTx)
-        external view returns (uint256 l1DataCostTEA, uint256 l1GasUsed)
-    {
-        // Deposit transactions are not included in blobs, so do not pay any L1 Data Cost.
-        if (isDepositTx) return (0, 0);
-
-        // Implement the Fjord calculation to determine the ETH L1 Data Cost.
-        uint256 l1DataCostETH;
-        (l1DataCostETH, l1GasUsed) = _calculateL1DataCostFjord(fastLzSize);
-
-        // Use TeaWAPOracle to adjust the cost from ETH to $TEA.
-        (uint256 nativeTokenPerETH, uint256 oracleDecimals) = _getTEAPerETH();
-        if (nativeTokenPerETH == 0) {
-            nativeTokenPerETH = BACKUP_TEA_PER_ETH;
-            oracleDecimals = 0;
-        }
-
-        l1DataCostTEA = l1DataCostETH * nativeTokenPerETH / (10 ** oracleDecimals);
-    }
-
-    // Implements: https://specs.optimism.io/protocol/fjord/exec-engine.html#fees
-    function _calculateL1DataCostFjord(uint256 fastLzSize) internal view returns (uint256, uint256) {
-        // Fjord L1 cost function:
-		// l1FeeScaled = baseFeeScalar*l1BaseFee*16 + blobFeeScalar*l1BlobBaseFee
-		// estimatedSize = max(minTransactionSize, intercept + fastlzCoef*fastlzSize)
-		// l1Cost = estimatedSize * l1FeeScaled / 1e12
-
-        uint256 cdCostPerByte = baseFeeScalar * basefee * 16;
-        uint256 blobCostPerByte = blobBaseFeeScalar * blobBaseFee;
-        uint256 l1FeeScaled = cdCostPerByte + blobCostPerByte;
-
-        uint256 estimatedSize = (fastLzSize * L1_COST_FASTLZ_COEF) - L1_COST_INTERCEPT_POSITIVE;
-        if (estimatedSize < MIN_TRANSACTION_SIZE_SCALED) estimatedSize = MIN_TRANSACTION_SIZE_SCALED;
-
-        uint256 l1Cost = l1FeeScaled * uint256(estimatedSize) / 1e12;
-        uint256 cdGasUsed = uint256(estimatedSize) * 16 / 1e6;
-
-        return (l1Cost, cdGasUsed);
+    function _tryCacheLatestOraclePrice() internal {
+        (Predeploys.GAS_PRICE_ORACLE).call(abi.encodeWithSignature("cacheLatestOraclePrice()"));
     }
 }

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -17,7 +17,7 @@ contract TeaWAPOracle {
     bytes32 internal constant CUSTOM_GAS_TOKEN_ORACLE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.oracle")) - 1);
 
     /// @notice The storage slot that contains the fallback price, set by admin
-    uint256 internal constant FALLBACK_PRICE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.fallbackprice")) - 1);
+    bytes32 internal constant FALLBACK_PRICE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.fallbackprice")) - 1);
 
     /// @notice A backup TEA/ETH ratio, in the case that the oracle is not set
     ///         and the fallback price is not set.
@@ -35,7 +35,7 @@ contract TeaWAPOracle {
 
     /// @notice Convert the inputted amount of ETH (18 decimals) to $TEA
     /// @dev amount (18 decimals) * teaPerETH (18 decimals) / 1e18 = teaAmount (18 decimals)
-    function convertETHToTea(uint256 amount) external view returns (uint256) {
+    function convertETHToTea(uint256 amount) public view returns (uint256) {
         return amount * teaPerETH() / 1e18;
     }
 
@@ -97,7 +97,7 @@ contract TeaWAPOracle {
 
         _setFallbackPrice(_price);
 
-        emit FallbackPriceUpdated(_price, _decimals);
+        emit FallbackPriceUpdated(_price);
     }
 
     ////////////////////////////////
@@ -119,7 +119,7 @@ contract TeaWAPOracle {
     function getOracleConfig() public view returns (uint96, address) {
         uint256 data = Storage.getUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT);
 
-        uint8 twapObservations = uint96(data >> 160);
+        uint96 twapObservations = uint96(data >> 160);
         address oracle = address(uint160(data));
 
         return (twapObservations, oracle);

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -5,7 +5,6 @@ import { Storage } from "src/libraries/Storage.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { IVelodromePool } from "src/L2/interfaces/IVelodromePool.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
-import { IERC20 } from "lib/forge-std/src/interfaces/IERC20.sol";
 
 contract TeaWAPOracle {
     ////////////////////////////////
@@ -20,7 +19,7 @@ contract TeaWAPOracle {
     /// @dev bool(token0?) | address(WETH)
     bytes32 public constant WETH_ADDRESS_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.weth")) - 1);
 
-    /// @notice The storage slot for the latest price data
+    /// @notice The storage slot for the latest price
     /// @dev uint96(latestTime) | uint160(latestPrice)
     bytes32 public constant CUSTOM_GAS_TOKEN_PRICE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.price")) - 1);
 

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -3,10 +3,9 @@ pragma solidity 0.8.15;
 
 import { Storage } from "src/libraries/Storage.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
-// todo: what if this is upgraded? before and after that tx will be different
-// this means option 2
+import { IVelodromePool } from "src/L2/interfaces/IVelodromePool.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { IERC20 } from "lib/forge-std/src/interfaces/IERC20.sol";
 
 contract TeaWAPOracle {
     ////////////////////////////////
@@ -15,18 +14,33 @@ contract TeaWAPOracle {
 
     /// @notice The storage slot that contains data about the TWAP
     /// @dev  uint96(twapObservations) | address(oracle)
-    bytes32 internal constant CUSTOM_GAS_TOKEN_ORACLE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.oracle")) - 1);
+    bytes32 public constant CUSTOM_GAS_TOKEN_ORACLE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.oracle")) - 1);
+
+    /// @notice The storage slot for the WETH address and its token position in the oracle
+    /// @dev bool(token0?) | address(WETH)
+    bytes32 public constant WETH_ADDRESS_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.weth")) - 1);
+
+    /// @notice The storage slot for the latest price data
+    /// @dev uint96(latestTime) | uint160(latestPrice)
+    bytes32 public constant CUSTOM_GAS_TOKEN_PRICE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.price")) - 1);
 
     /// @notice The storage slot that contains the fallback price, set by admin
-    bytes32 internal constant FALLBACK_PRICE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.fallbackprice")) - 1);
+    bytes32 public constant FALLBACK_PRICE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.fallbackprice")) - 1);
 
     /// @notice A backup TEA/ETH ratio, in the case that the oracle is not set
     ///         and the fallback price is not set.
-    uint256 public constant BACKUP_TEA_WEI_PER_ETH = 1_500_000e18;
+    uint160 public constant BACKUP_TEA_WEI_PER_ETH = 1_500_000e18;
 
     /// @notice The minimum WETH balance of the pool needed for the oracle to be valid.
-    /// @dev If the pool has less than this WETH balance, it may be too easy to manipulate.
+    /// @dev If the pool has less than this balance, it may be too easy to manipulate.
     uint256 public constant MIN_WETH_BALANCE = 1e18;
+
+    /// @notice The maximum amount of time we will allow failed oracle calls before
+    ///         setting the storage value to the fallback.
+    uint256 public constant MAX_ORACLE_DOWNTIME = 1 hours;
+
+    /// @notice Emitted when the price is updated
+    event NewPriceSet(uint160 price);
 
     /// @notice Emitted when the oracle configuration is updated
     event OracleConfigUpdated(uint96 twapObservations, address oracle);
@@ -47,38 +61,52 @@ contract TeaWAPOracle {
     /// @notice Get the price of price of 1 Ether (1e18) in $TEA (18 decimals).
     /// @dev If the oracle is not set, we will return fallback price (also in 18 decimals).
     /// @dev If the fallback price is also not set, we will return a hardcoded backup.
-    function teaPerETH() public view returns (uint256) {
+    function teaPerETH() public view returns (uint160) {
         // Load oracle config from storage.
-        (uint96 twapObservations, address oracle) = getOracleConfig();
+        (
+            address oracle,
+            uint96 twapObservations,
+            bool wethT0,
+            address weth
+        ) = getOracleConfig();
 
-        // Load fallback price from storage. (If it hasn't been set, use hardcoded backup.)
-        uint256 fallbackPrice = getFallbackPrice();
-        if (fallbackPrice == 0) fallbackPrice = BACKUP_TEA_WEI_PER_ETH;
+        // Load fallback price from storage.
+        // If it hasn't been set, this will return hardcoded backup.
+        uint160 fallbackPrice = getFallbackPrice();
 
         // If there is no oracle set, return the fallback price.
         if (oracle == address(0)) return fallbackPrice;
 
-        // If there is too little WETH in the pool, it may be manipulated.
-        // @todo any reason to use `reserves` from the pool instead?
-        if (IERC20(Predeploys.WETH).balanceOf(oracle) < MIN_WETH_BALANCE) return fallbackPrice;
+        // If there is too little value in the pool, it may be manipulated.
+        (bool success, bytes memory returndata) = oracle.staticcall(
+            abi.encodeWithSignature("getReserves()")
+        );
+        if (!success || returndata.length != 96) return fallbackPrice;
+        (uint r0, uint r1,) = abi.decode(returndata, (uint, uint, uint));
+
+        // Use WETH reserves for this reliability, because it's the more stable token price.
+        uint256 wethReserves = wethT0 ? r0 : r1;
+        if (wethReserves < MIN_WETH_BALANCE) return fallbackPrice;
 
         // Call the oracle to get the time weighted price.
         // https://github.com/velodrome-finance/contracts/blob/main/contracts/Pool.sol
         // quote(address tokenIn, uint256 amountIn, uint256 granularity)
-        (bool success, bytes memory returndata) = oracle.staticcall(
+        (success, returndata) = oracle.staticcall(
             abi.encodeWithSignature(
-                "quote(address,uint256,uin256)",
-                Predeploys.WETH, 1e18, twapObservations
+                "quote(address,uint256,uint256)",
+                weth, 1e18, twapObservations
             )
         );
 
-        // Ensure this function doesn't revert.
         // It will revert if we don't have sufficient data points saved.
-        if (!success || returndata.length < 32) return 0;
+        if (!success || returndata.length < 32) return fallbackPrice;
 
-        // Return the price, or the fallback price if the price is 0.
+        // Return the price, or the fallback price if the price is out of range.
         uint256 price = abi.decode(returndata, (uint256));
-        return price > 0 ? price : fallbackPrice;
+        if (price == 0 || price > type(uint160).max) {
+            return fallbackPrice;
+        }
+        return uint160(price);
     }
 
     ////////////////////////////////
@@ -88,8 +116,7 @@ contract TeaWAPOracle {
     /// @param _twapObservations Number of observations to ask from the oracle
     /// @param _oracle Address of the oracle contract to use
     function setOracleConfig(uint96 _twapObservations, address _oracle) external  {
-        // todo: is this the right admin?
-        require(msg.sender == Predeploys.PROXY_ADMIN, "TeaWAPOracle: admin only");
+        require(msg.sender == Ownable(Predeploys.PROXY_ADMIN).owner(), "TeaWAPOracle: admin only");
         require(_oracle != address(0), "VelodromeOracle: zero address");
         require(_twapObservations > 0, "VelodromeOracle: zero observations");
 
@@ -100,8 +127,8 @@ contract TeaWAPOracle {
 
     /// @param _price Fallback price to use if oracle fails
     /// @dev Price should be set in wei of $TEA per 18 decimals of ETH
-    function setFallbackPrice(uint256 _price) external {
-        require(msg.sender == Predeploys.PROXY_ADMIN, "TeaWAPOracle: admin only");
+    function setFallbackPrice(uint160 _price) external {
+        require(msg.sender == Ownable(Predeploys.PROXY_ADMIN).owner(), "TeaWAPOracle: admin only");
         require(_price > 0, "VelodromeOracle: zero price");
 
         _setFallbackPrice(_price);
@@ -113,29 +140,79 @@ contract TeaWAPOracle {
     ///// STORAGE READ / WRITE /////
     ////////////////////////////////
 
-    /// @return The fallback price to use if the oracle fails
+    /// @return The latest price data from the oracle
     /// @dev Price is in wei of $TEA per 18 decimals of ETH
-    function getFallbackPrice() public view returns (uint256) {
-        return Storage.getUint(FALLBACK_PRICE_SLOT);
+    function getLatestPrice() public view returns (uint96, uint160) {
+        uint256 data = Storage.getUint(CUSTOM_GAS_TOKEN_PRICE_SLOT);
+
+        uint96 latestTime = uint96(data >> 160);
+        uint160 latestPrice = uint160(data);
+
+        return (latestTime, latestPrice);
     }
 
-    function _setFallbackPrice(uint256 _price) internal {
+    function _setLatestPrice(uint160 _price) internal {
+        uint256 data = uint256(block.timestamp) << 160 | uint160(_price);
+        Storage.setUint(CUSTOM_GAS_TOKEN_PRICE_SLOT, data);
+
+        emit NewPriceSet(_price);
+    }
+
+    /// @return The fallback price to use if the oracle fails
+    /// @dev Price is in wei of $TEA per 18 decimals of ETH
+    /// @dev If the fallback price isn't set, returns a hardcoded backup.
+    function getFallbackPrice() public view returns (uint160) {
+        uint256 fallbackPrice = Storage.getUint(FALLBACK_PRICE_SLOT);
+        if (fallbackPrice == 0) fallbackPrice = BACKUP_TEA_WEI_PER_ETH;
+
+        // This downcast is safe because the setter stores the value as a uint160.
+        return uint160(fallbackPrice);
+    }
+
+    function _setFallbackPrice(uint160 _price) internal {
         Storage.setUint(FALLBACK_PRICE_SLOT, _price);
     }
 
-    /// @return twapObservations The number of TWAP observations to use with the oracle
     /// @return oracle The address of the oracle contract that is being used
-    function getOracleConfig() public view returns (uint96, address) {
+    /// @return twapObservations The number of TWAP observations to use with the oracle
+    /// @return wethT0 Whether WETH is token0 in the oracle
+    /// @return weth The address of the WETH token in the oracle
+    function getOracleConfig() public view returns (address, uint96, bool, address) {
         uint256 data = Storage.getUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT);
 
         uint96 twapObservations = uint96(data >> 160);
         address oracle = address(uint160(data));
 
-        return (twapObservations, oracle);
+        data = Storage.getUint(WETH_ADDRESS_SLOT);
+        address weth = address(uint160(data));
+        bool wethT0 = data >> 160 == 1;
+
+        return (oracle, twapObservations, wethT0, weth);
     }
 
     function _setOracleConfig(uint96 _twapObservations, address _oracle) internal {
-        uint256 data = uint256(_twapObservations) << 160 | uint160(_oracle);
-        Storage.setUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT, data);
+        // These tokens should be WTEA and WETH.
+        (address t0, address t1) = IVelodromePool(_oracle).tokens();
+
+        // Predeploys.WETH is WTEA, which must be one of the two tokens.
+        // WETH should be at the opposite address.
+        address weth;
+        if (t0 == Predeploys.WETH) weth = t1;
+        else if (t1 == Predeploys.WETH) weth = t0;
+        else revert("TeaWAPOracle: WTEA not in pool");
+
+        bool wethT0 = weth == t0;
+
+        // Sanity check. This can of course be gamed, but is just meant to catch mistakes.
+        (, bytes memory bytesName) = weth.staticcall(abi.encodeWithSignature("name()"));
+        require(keccak256(bytesName) == keccak256(abi.encode("Wrapped Ether")));
+
+        Storage.setUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT,
+            uint256(_twapObservations) << 160 | uint160(_oracle)
+        );
+
+        Storage.setUint(WETH_ADDRESS_SLOT,
+            uint256(wethT0 ? 1 : 0) << 160 | uint160(weth)
+        );
     }
 }

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -23,6 +23,10 @@ contract TeaWAPOracle {
     ///         and the fallback price is not set.
     uint256 public constant BACKUP_TEA_WEI_PER_ETH = 1_500_000e18;
 
+    /// @notice The minimum WETH balance of the pool needed for the oracle to be valid.
+    /// @dev If the pool has less than this WETH balance, it may be too easy to manipulate.
+    uint256 public constant MIN_WETH_BALANCE = 1e18;
+
     /// @notice Emitted when the oracle configuration is updated
     event OracleConfigUpdated(uint96 twapObservations, address oracle);
 
@@ -52,6 +56,10 @@ contract TeaWAPOracle {
 
         // If there is no oracle set, return the fallback price.
         if (oracle == address(0)) return fallbackPrice;
+
+        // If there is too little WETH in the pool, it may be manipulated.
+        // @todo any reason to use `reserves` from the pool instead?
+        if (IERC20(Predeploys.WETH).balanceOf(oracle) < MIN_WETH_BALANCE) return fallbackPrice;
 
         // Call the oracle to get the time weighted price.
         // https://github.com/velodrome-finance/contracts/blob/main/contracts/Pool.sol

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -13,11 +13,19 @@ contract TeaWAPOracle {
     ////////////////////////////////
 
     /// @notice The storage slot that contains data about the TWAP
-    /// @dev  uint80(fallbackPrice) | uint8(fallbackPriceDecimals) | uint8(twapObservations) | address(oracle)
-    bytes32 internal constant CUSTOM_GAS_TOKEN_ORACLE_SLOT = bytes32(uint256(keccak256("opstack.customgastokenoracle")) - 1);
+    /// @dev  uint96(twapObservations) | address(oracle)
+    bytes32 internal constant CUSTOM_GAS_TOKEN_ORACLE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.oracle")) - 1);
 
-    /// @notice The number of decimals that the oracle's result will be returned in
-    uint256 constant ORACLE_DECIMALS = 18;
+    /// @notice The storage slot that contains the fallback price, set by admin
+    uint256 internal constant FALLBACK_PRICE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.fallbackprice")) - 1);
+
+    /// @notice The storage slot that contains the last known oracle price
+    /// @dev uint128(blockTime) | uint128(price)
+    uint256 internal constant CACHED_ORACLE_PRICE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.cachedprice")) - 1);
+
+    /// @notice A backup TEA/ETH ratio, in the case that the oracle is not set
+    ///         and the fallback price is not set.
+    uint256 public constant BACKUP_TEA_WEI_PER_ETH = 1_500_000e18;
 
     /// @notice Emitted when the oracle configuration is updated
     event VelodromeConfigUpdated(uint8 twapObservations, address oracle);
@@ -25,30 +33,62 @@ contract TeaWAPOracle {
     /// @notice Emitted when the fallback price is updated
     event FallbackPriceUpdated(uint80 price, uint8 decimals);
 
+    /// @notice Emitted when oracle price is cached
+    event OraclePriceCached(uint128 blockTime, uint128 price);
+
     ////////////////////////////////
     ///// ORACLE FUNCTIONALITY /////
     ////////////////////////////////
 
-    /// @dev If the oracle is not set, we will return fallback price & decimals.
-    ///      If the fallback price is not set, it will override with a backup in L1Block.sol.
-    function _getTEAPerETH() internal view returns (uint256, uint256) {
-        (uint80 fallbackPrice, uint8 fallbackDecimals, uint8 twapObservations, address oracle) = getOracleConfig();
+    /// @notice Cache the latest oracle price in storage.
+    /// @dev This price is used by the mempool to estimate L1 Data Costs when it doesn't have
+    ///      access to the EVM.
+    function cacheLatestOraclePrice() external {
+        require(msg.sender == Predeploys.L1_BLOCK_ATTRIBUTES, "TeaWAPOracle: L1Block only");
 
-        if (oracle == address(0)) return (fallbackPrice, fallbackDecimals);
+        uint256 price = _getPrice();
 
+        if (price > 0) {
+            _setCachedOraclePrice(uint128(block.timestamp), uint128(price));
+            emit OraclePriceCached(uint128(block.timestamp), uint128(price));
+        }
+    }
+
+    function convertToTea(uint256 amount) external view returns (uint256) {
+        return amount * _getTeaPerEth() / 1e18;
+    }
+
+    /// @notice Get the price of price of 1 Ether (1e18) in $TEA (18 decimals).
+    /// @dev If the oracle is not set, we will return fallback price (also in 18 decimals).
+    /// @dev If the fallback price is also not set, we will return a hardcoded backup.
+    function _getTeaPerEth() public view returns (uint256) {
+        (uint80 fallbackPrice, uint8 twapObservations, address oracle) = getOracleConfig();
+
+        if (fallbackPrice == 0) fallbackPrice = BACKUP_TEA_WEI_PER_ETH;
+
+        if (oracle == address(0)) return fallbackPrice;
+
+        (bool success, uint256 price) = _getPrice(oracle, twapObservations);
+
+        if (price == 0) return fallbackPrice;
+
+        return price;
+    }
+
+    function _getPrice(address oracle) internal view returns (uint256 price) {
         // https://github.com/velodrome-finance/contracts/blob/main/contracts/Pool.sol
         // quote(address tokenIn, uint256 amountIn, uint256 granularity)
         (bool success, bytes memory returndata) = oracle.staticcall(
             abi.encodeWithSignature(
                 "quote(address,uint256,uin256)",
-                Predeploys.WETH, 10 ** ORACLE_DECIMALS, twapObservations
+                Predeploys.WETH, 1e18, twapObservations
             )
         );
 
         // It will revert if we don't have sufficient data points saved.
-        if (!success || returndata.length < 32) return (fallbackPrice, fallbackDecimals);
+        if (!success || returndata.length < 32) return 0;
 
-        return (abi.decode(returndata, (uint256)), ORACLE_DECIMALS);
+        return abi.decode(returndata, (uint256));
     }
 
     ////////////////////////////////
@@ -85,24 +125,39 @@ contract TeaWAPOracle {
     ///// STORAGE READ / WRITE /////
     ////////////////////////////////
 
-    function getOracleConfig() public view returns (uint80, uint8, uint8, address) {
-        uint256 data = Storage.getUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT);
-
-        uint80 fallbackPrice = uint80(data >> 176);
-        uint8 fallbackPriceDecimals = uint8(data >> 168);
-        uint8 twapObservations = uint8(data >> 160);
-        address oracle = address(uint160(data));
-
-        return (fallbackPrice, fallbackPriceDecimals, twapObservations, oracle);
+    function getFallbackPrice() public view returns (uint256) {
+        return Storage.getUint(FALLBACK_PRICE_SLOT);
     }
 
-    function _setOracleConfig(uint80 fallbackPrice, uint8 fallbackDecimals, uint8 twapObservations, address oracle) public {
-        uint256 value = (
-            uint256(fallbackPrice << 176) |
-            uint256(fallbackDecimals << 168) |
-            uint256(twapObservations << 160) |
-            uint256(uint160(oracle))
-        );
-        Storage.setUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT, value);
+    function _setFallbackPrice(uint256 _price) internal {
+        Storage.setUint(FALLBACK_PRICE_SLOT, _price);
+    }
+
+    function getOracleConfig() public view returns (uint96, address) {
+        uint256 data = Storage.getUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT);
+
+        uint8 twapObservations = uint96(data >> 160);
+        address oracle = address(uint160(data));
+
+        return (twapObservations, oracle);
+    }
+
+    function _setOracleConfig(uint96 _twapObservations, address _oracle) internal {
+        uint256 data = uint256(_twapObservations) << 160 | uint160(_oracle);
+        Storage.setUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT, data);
+    }
+
+    function getCachedOraclePrice() public view returns (uint128, uint128) {
+        uint256 data = Storage.getUint(CACHED_ORACLE_PRICE_SLOT);
+
+        uint128 blockTime = uint128(data >> 128);
+        uint128 price = uint128(data);
+
+        return (blockTime, price);
+    }
+
+    function _setCachedOraclePrice(uint128 _blockTime, uint128 _price) internal {
+        uint256 data = uint256(_blockTime) << 128 | uint128(_price);
+        Storage.setUint(CACHED_ORACLE_PRICE_SLOT, data);
     }
 }

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Storage } from "src/libraries/Storage.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
+
+// todo: what if this is upgraded? before and after that tx will be different
+// this means option 2
+
+contract TeaWAPOracle {
+    ////////////////////////////////
+    /////// STORAGE & EVENTS ///////
+    ////////////////////////////////
+
+    /// @notice The storage slot that contains data about the TWAP
+    /// @dev  uint80(fallbackPrice) | uint8(fallbackPriceDecimals) | uint8(twapObservations) | address(oracle)
+    bytes32 internal constant CUSTOM_GAS_TOKEN_ORACLE_SLOT = bytes32(uint256(keccak256("opstack.customgastokenoracle")) - 1);
+
+    /// @notice The number of decimals that the oracle's result will be returned in
+    uint256 constant ORACLE_DECIMALS = 18;
+
+    /// @notice Emitted when the oracle configuration is updated
+    event VelodromeConfigUpdated(uint8 twapObservations, address oracle);
+
+    /// @notice Emitted when the fallback price is updated
+    event FallbackPriceUpdated(uint80 price, uint8 decimals);
+
+    ////////////////////////////////
+    ///// ORACLE FUNCTIONALITY /////
+    ////////////////////////////////
+
+    /// @dev If the oracle is not set, we will return fallback price & decimals.
+    ///      If the fallback price is not set, it will override with a backup in L1Block.sol.
+    function _getTEAPerETH() internal view returns (uint256, uint256) {
+        (uint80 fallbackPrice, uint8 fallbackDecimals, uint8 twapObservations, address oracle) = getOracleConfig();
+
+        if (oracle == address(0)) return (fallbackPrice, fallbackDecimals);
+
+        // https://github.com/velodrome-finance/contracts/blob/main/contracts/Pool.sol
+        // quote(address tokenIn, uint256 amountIn, uint256 granularity)
+        (bool success, bytes memory returndata) = oracle.staticcall(
+            abi.encodeWithSignature(
+                "quote(address,uint256,uin256)",
+                Predeploys.WETH, 10 ** ORACLE_DECIMALS, twapObservations
+            )
+        );
+
+        // It will revert if we don't have sufficient data points saved.
+        if (!success || returndata.length < 32) return (fallbackPrice, fallbackDecimals);
+
+        return (abi.decode(returndata, (uint256)), ORACLE_DECIMALS);
+    }
+
+    ////////////////////////////////
+    //////////// ADMIN /////////////
+    ////////////////////////////////
+
+    function setVelodromeConfig(uint8 _twapObservations, address _oracle) external  {
+        // todo: is this the right admin?
+        require(msg.sender == Predeploys.PROXY_ADMIN, "TeaWAPOracle: admin only");
+        require(_oracle != address(0), "VelodromeOracle: zero address");
+        require(_twapObservations > 0, "VelodromeOracle: zero observations");
+
+        (uint80 fallbackPrice, uint8 fallbackDecimals,,) = getOracleConfig();
+        _setOracleConfig(fallbackPrice, fallbackDecimals, _twapObservations, _oracle);
+
+        emit VelodromeConfigUpdated(_twapObservations, _oracle);
+    }
+
+    /// @dev _price = Native Token per ETH (with _decimals of precision)
+    ///      For example, if $TEA is worth 1/10th of ETH, we could represent
+    ///      this as 10 with 0 decimals of precision. If 1 $TEA was worth
+    ///      2 ETH, we would need to set _price = 5 and _decimals = 1.
+    function setFallbackPrice(uint80 _price, uint8 _decimals) external {
+        require(msg.sender == Predeploys.PROXY_ADMIN, "TeaWAPOracle: admin only");
+        require(_price > 0, "VelodromeOracle: zero price");
+
+        (,, uint8 twapObservations, address oracle) = getOracleConfig();
+        _setOracleConfig(_price, _decimals, twapObservations, oracle);
+
+        emit FallbackPriceUpdated(_price, _decimals);
+    }
+
+    ////////////////////////////////
+    ///// STORAGE READ / WRITE /////
+    ////////////////////////////////
+
+    function getOracleConfig() public view returns (uint80, uint8, uint8, address) {
+        uint256 data = Storage.getUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT);
+
+        uint80 fallbackPrice = uint80(data >> 176);
+        uint8 fallbackPriceDecimals = uint8(data >> 168);
+        uint8 twapObservations = uint8(data >> 160);
+        address oracle = address(uint160(data));
+
+        return (fallbackPrice, fallbackPriceDecimals, twapObservations, oracle);
+    }
+
+    function _setOracleConfig(uint80 fallbackPrice, uint8 fallbackDecimals, uint8 twapObservations, address oracle) public {
+        uint256 value = (
+            uint256(fallbackPrice << 176) |
+            uint256(fallbackDecimals << 168) |
+            uint256(twapObservations << 160) |
+            uint256(uint160(oracle))
+        );
+        Storage.setUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT, value);
+    }
+}

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -19,63 +19,41 @@ contract TeaWAPOracle {
     /// @notice The storage slot that contains the fallback price, set by admin
     uint256 internal constant FALLBACK_PRICE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.fallbackprice")) - 1);
 
-    /// @notice The storage slot that contains the last known oracle price
-    /// @dev uint128(blockTime) | uint128(price)
-    uint256 internal constant CACHED_ORACLE_PRICE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.cachedprice")) - 1);
-
     /// @notice A backup TEA/ETH ratio, in the case that the oracle is not set
     ///         and the fallback price is not set.
     uint256 public constant BACKUP_TEA_WEI_PER_ETH = 1_500_000e18;
 
     /// @notice Emitted when the oracle configuration is updated
-    event VelodromeConfigUpdated(uint8 twapObservations, address oracle);
+    event OracleConfigUpdated(uint96 twapObservations, address oracle);
 
     /// @notice Emitted when the fallback price is updated
-    event FallbackPriceUpdated(uint80 price, uint8 decimals);
-
-    /// @notice Emitted when oracle price is cached
-    event OraclePriceCached(uint128 blockTime, uint128 price);
+    event FallbackPriceUpdated(uint256 price);
 
     ////////////////////////////////
     ///// ORACLE FUNCTIONALITY /////
     ////////////////////////////////
 
-    /// @notice Cache the latest oracle price in storage.
-    /// @dev This price is used by the mempool to estimate L1 Data Costs when it doesn't have
-    ///      access to the EVM.
-    function cacheLatestOraclePrice() external {
-        require(msg.sender == Predeploys.L1_BLOCK_ATTRIBUTES, "TeaWAPOracle: L1Block only");
-
-        uint256 price = _getPrice();
-
-        if (price > 0) {
-            _setCachedOraclePrice(uint128(block.timestamp), uint128(price));
-            emit OraclePriceCached(uint128(block.timestamp), uint128(price));
-        }
-    }
-
-    function convertToTea(uint256 amount) external view returns (uint256) {
-        return amount * _getTeaPerEth() / 1e18;
+    /// @notice Convert the inputted amount of ETH (18 decimals) to $TEA
+    /// @dev amount (18 decimals) * teaPerETH (18 decimals) / 1e18 = teaAmount (18 decimals)
+    function convertETHToTea(uint256 amount) external view returns (uint256) {
+        return amount * teaPerETH() / 1e18;
     }
 
     /// @notice Get the price of price of 1 Ether (1e18) in $TEA (18 decimals).
     /// @dev If the oracle is not set, we will return fallback price (also in 18 decimals).
     /// @dev If the fallback price is also not set, we will return a hardcoded backup.
-    function _getTeaPerEth() public view returns (uint256) {
-        (uint80 fallbackPrice, uint8 twapObservations, address oracle) = getOracleConfig();
+    function teaPerETH() public view returns (uint256) {
+        // Load oracle config from storage.
+        (uint96 twapObservations, address oracle) = getOracleConfig();
 
+        // Load fallback price from storage. (If it hasn't been set, use hardcoded backup.)
+        uint256 fallbackPrice = getFallbackPrice();
         if (fallbackPrice == 0) fallbackPrice = BACKUP_TEA_WEI_PER_ETH;
 
+        // If there is no oracle set, return the fallback price.
         if (oracle == address(0)) return fallbackPrice;
 
-        (bool success, uint256 price) = _getPrice(oracle, twapObservations);
-
-        if (price == 0) return fallbackPrice;
-
-        return price;
-    }
-
-    function _getPrice(address oracle) internal view returns (uint256 price) {
+        // Call the oracle to get the time weighted price.
         // https://github.com/velodrome-finance/contracts/blob/main/contracts/Pool.sol
         // quote(address tokenIn, uint256 amountIn, uint256 granularity)
         (bool success, bytes memory returndata) = oracle.staticcall(
@@ -85,38 +63,39 @@ contract TeaWAPOracle {
             )
         );
 
+        // Ensure this function doesn't revert.
         // It will revert if we don't have sufficient data points saved.
         if (!success || returndata.length < 32) return 0;
 
-        return abi.decode(returndata, (uint256));
+        // Return the price, or the fallback price if the price is 0.
+        uint256 price = abi.decode(returndata, (uint256));
+        return price > 0 ? price : fallbackPrice;
     }
 
     ////////////////////////////////
     //////////// ADMIN /////////////
     ////////////////////////////////
 
-    function setVelodromeConfig(uint8 _twapObservations, address _oracle) external  {
+    /// @param _twapObservations Number of observations to ask from the oracle
+    /// @param _oracle Address of the oracle contract to use
+    function setOracleConfig(uint96 _twapObservations, address _oracle) external  {
         // todo: is this the right admin?
         require(msg.sender == Predeploys.PROXY_ADMIN, "TeaWAPOracle: admin only");
         require(_oracle != address(0), "VelodromeOracle: zero address");
         require(_twapObservations > 0, "VelodromeOracle: zero observations");
 
-        (uint80 fallbackPrice, uint8 fallbackDecimals,,) = getOracleConfig();
-        _setOracleConfig(fallbackPrice, fallbackDecimals, _twapObservations, _oracle);
+        _setOracleConfig(_twapObservations, _oracle);
 
-        emit VelodromeConfigUpdated(_twapObservations, _oracle);
+        emit OracleConfigUpdated(_twapObservations, _oracle);
     }
 
-    /// @dev _price = Native Token per ETH (with _decimals of precision)
-    ///      For example, if $TEA is worth 1/10th of ETH, we could represent
-    ///      this as 10 with 0 decimals of precision. If 1 $TEA was worth
-    ///      2 ETH, we would need to set _price = 5 and _decimals = 1.
-    function setFallbackPrice(uint80 _price, uint8 _decimals) external {
+    /// @param _price Fallback price to use if oracle fails
+    /// @dev Price should be set in wei of $TEA per 18 decimals of ETH
+    function setFallbackPrice(uint256 _price) external {
         require(msg.sender == Predeploys.PROXY_ADMIN, "TeaWAPOracle: admin only");
         require(_price > 0, "VelodromeOracle: zero price");
 
-        (,, uint8 twapObservations, address oracle) = getOracleConfig();
-        _setOracleConfig(_price, _decimals, twapObservations, oracle);
+        _setFallbackPrice(_price);
 
         emit FallbackPriceUpdated(_price, _decimals);
     }
@@ -125,6 +104,8 @@ contract TeaWAPOracle {
     ///// STORAGE READ / WRITE /////
     ////////////////////////////////
 
+    /// @return The fallback price to use if the oracle fails
+    /// @dev Price is in wei of $TEA per 18 decimals of ETH
     function getFallbackPrice() public view returns (uint256) {
         return Storage.getUint(FALLBACK_PRICE_SLOT);
     }
@@ -133,6 +114,8 @@ contract TeaWAPOracle {
         Storage.setUint(FALLBACK_PRICE_SLOT, _price);
     }
 
+    /// @return twapObservations The number of TWAP observations to use with the oracle
+    /// @return oracle The address of the oracle contract that is being used
     function getOracleConfig() public view returns (uint96, address) {
         uint256 data = Storage.getUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT);
 
@@ -145,19 +128,5 @@ contract TeaWAPOracle {
     function _setOracleConfig(uint96 _twapObservations, address _oracle) internal {
         uint256 data = uint256(_twapObservations) << 160 | uint160(_oracle);
         Storage.setUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT, data);
-    }
-
-    function getCachedOraclePrice() public view returns (uint128, uint128) {
-        uint256 data = Storage.getUint(CACHED_ORACLE_PRICE_SLOT);
-
-        uint128 blockTime = uint128(data >> 128);
-        uint128 price = uint128(data);
-
-        return (blockTime, price);
-    }
-
-    function _setCachedOraclePrice(uint128 _blockTime, uint128 _price) internal {
-        uint256 data = uint256(_blockTime) << 128 | uint128(_price);
-        Storage.setUint(CACHED_ORACLE_PRICE_SLOT, data);
     }
 }

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.15;
 
 import { Storage } from "src/libraries/Storage.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 // todo: what if this is upgraded? before and after that tx will be different
 // this means option 2

--- a/packages/contracts-bedrock/src/L2/interfaces/IGasPriceOracle.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/IGasPriceOracle.sol
@@ -21,5 +21,17 @@ interface IGasPriceOracle {
     function setFjord() external;
     function version() external view returns (string memory);
 
+    function updateGasTokenPriceRatio() external;
+    function convertETHToTea(uint256) external view returns (uint256);
+    function teaPerETH() external view returns (uint160);
+    function getLatestPrice() external view returns (uint96, uint160);
+    function getFallbackPrice() external view returns (uint160);
+    function getOracleConfig() external view returns (address,uint96,bool,address);
+    function setOracleConfig(uint96,address) external;
+    function CUSTOM_GAS_TOKEN_ORACLE_SLOT() external view returns (bytes32);
+    function WETH_ADDRESS_SLOT() external view returns (bytes32);
+    function CUSTOM_GAS_TOKEN_PRICE_SLOT() external view returns (bytes32);
+    function FALLBACK_PRICE_SLOT() external view returns (bytes32);
+
     function __constructor__() external;
 }

--- a/packages/contracts-bedrock/src/L2/interfaces/IVelodromePool.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/IVelodromePool.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IVelodromePool {
+    function tokens() external view returns (address, address);
+    function getReserves() external view returns (uint256, uint256, uint256);
+}

--- a/packages/contracts-bedrock/test/L2/L1Block.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Block.t.sol
@@ -202,17 +202,3 @@ contract L1BlockCustomGasToken_Test is L1BlockTest {
         l1Block.setGasPayingToken(address(this), 18, "Test", "TST");
     }
 }
-
-contract L1BlockGetL1DataCost is L1BlockTest {
-    // deposit tx returns 0s
-
-    // zero fastLzSize returns minimum (no fallback)
-
-    // zero fastLzSize returns minimum (with fallback)
-
-    // zero fastLzSize returns minimum (with oracle, maybe OP Mainnet fork?)
-
-    // one example of larger fastLzSize working as expected
-
-    // changing scalarys and base fees changes appropriately (fuzz?)
-}

--- a/packages/contracts-bedrock/test/L2/L1Block.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Block.t.sol
@@ -202,3 +202,17 @@ contract L1BlockCustomGasToken_Test is L1BlockTest {
         l1Block.setGasPayingToken(address(this), 18, "Test", "TST");
     }
 }
+
+contract L1BlockGetL1DataCost is L1BlockTest {
+    // deposit tx returns 0s
+
+    // zero fastLzSize returns minimum (no fallback)
+
+    // zero fastLzSize returns minimum (with fallback)
+
+    // zero fastLzSize returns minimum (with oracle, maybe OP Mainnet fork?)
+
+    // one example of larger fastLzSize working as expected
+
+    // changing scalarys and base fees changes appropriately (fuzz?)
+}

--- a/packages/contracts-bedrock/test/L2/TeaWAPOracle.t.sol
+++ b/packages/contracts-bedrock/test/L2/TeaWAPOracle.t.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Testing utilities
+import { CommonTest } from "test/setup/CommonTest.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+
+contract OtherTokenWETH {
+    function name() public pure returns (string memory) {
+        return "Wrapped Ether";
+    }
+}
+
+contract OtherTokenNot {
+    function name() public pure returns (string memory) {
+        return "Not Wrapped Ether";
+    }
+}
+
+contract MockOracle {
+    address otherToken;
+    bool goodReserves;
+
+    constructor(address _otherToken, bool _goodReserves) {
+        otherToken = _otherToken;
+        goodReserves = _goodReserves;
+    }
+
+    function getReserves() public view returns (uint256, uint256, uint256) {
+        // Let's say this is 2mm WTEA for 1 WETH
+        // WTEA is token0 (at Predeploys.WETH)
+        if (goodReserves) return (0, 1e18, 0);
+        else return (0, 1e17, 0);
+    }
+
+    function tokens() public view returns (address, address) {
+        return (Predeploys.WETH, otherToken);
+    }
+
+    function quote(address token, uint256 amount, uint256) external view returns (uint256) {
+        if (token == Predeploys.WETH) {
+            return amount / 2_000_000;
+        } else {
+            return amount * 2_000_000;
+        }
+    }
+}
+
+contract TeaWAPOracle_Test is CommonTest {
+    MockOracle public oracle;
+    address myWeth;
+
+    function setUp() public override {
+        super.setUp();
+
+        // Start at a reasonable timestamp.
+        vm.warp(1737668792);
+
+        myWeth = address(new OtherTokenWETH());
+        oracle = new MockOracle(myWeth, true);
+    }
+
+    function testTeaWAP_UpdatePrice() public {
+        vm.prank(address(l1Block));
+        gasPriceOracle.updateGasTokenPriceRatio();
+
+        (uint96 ts, uint160 price) = gasPriceOracle.getLatestPrice();
+        assertEq(ts, block.timestamp);
+        assertEq(price, 1_500_000e18);
+
+        // This emulates what will happen in op-geth.
+        bytes32 priceData = vm.load(address(gasPriceOracle), gasPriceOracle.CUSTOM_GAS_TOKEN_PRICE_SLOT());
+        uint96 ts2 = uint96(uint256(priceData) >> 160);
+        uint160 price2 = uint160(uint256(priceData));
+
+        assertEq(ts2, block.timestamp);
+        assertEq(price2, 1_500_000e18);
+    }
+
+    function testTeaWAP_SetUpOracle() public {
+        vm.prank(Ownable(Predeploys.PROXY_ADMIN).owner());
+        gasPriceOracle.setOracleConfig(10, address(oracle));
+
+        (address oracle_, uint96 twapObservations, bool wethT0, address weth_) = gasPriceOracle.getOracleConfig();
+        assertEq(oracle_, address(oracle));
+        assertEq(twapObservations, 10);
+        assertFalse(wethT0);
+        assertEq(weth_, myWeth);
+    }
+
+    function testTeaWAP_GetPriceFromOracle() public {
+        vm.prank(Ownable(Predeploys.PROXY_ADMIN).owner());
+        gasPriceOracle.setOracleConfig(10, address(oracle));
+
+        vm.prank(address(l1Block));
+        gasPriceOracle.updateGasTokenPriceRatio();
+
+        (uint96 ts, uint160 price) = gasPriceOracle.getLatestPrice();
+        assert(ts == block.timestamp);
+        assert(price == oracle.quote(myWeth, 1e18, 10));
+    }
+
+    function testTeaWAP_FallbackIfBadReserves() public {
+        MockOracle badResevesOracle = new MockOracle(myWeth, false);
+        vm.prank(Ownable(Predeploys.PROXY_ADMIN).owner());
+        gasPriceOracle.setOracleConfig(10, address(badResevesOracle));
+
+        vm.prank(address(l1Block));
+        gasPriceOracle.updateGasTokenPriceRatio();
+
+        (uint96 ts, uint160 price) = gasPriceOracle.getLatestPrice();
+        assert(ts == block.timestamp);
+        assert(price == 1_500_000e18);
+    }
+
+    function testTeaWAP_StalePriceRevertToFallback() public {
+        vm.prank(Ownable(Predeploys.PROXY_ADMIN).owner());
+        gasPriceOracle.setOracleConfig(10, address(oracle));
+
+        vm.prank(address(l1Block));
+        gasPriceOracle.updateGasTokenPriceRatio();
+
+        (uint96 ts, uint160 price) = gasPriceOracle.getLatestPrice();
+        assert(ts == block.timestamp);
+        assert(price == 2_000_000e18);
+
+        // now let's break the oracle
+        vm.etch(address(oracle), abi.encode(""));
+
+        // after 59 minutes, should still skip
+        vm.warp(block.timestamp + 59 minutes);
+
+        vm.prank(address(l1Block));
+        gasPriceOracle.updateGasTokenPriceRatio();
+
+        (uint96 newTs, uint160 newPrice) = gasPriceOracle.getLatestPrice();
+        assert(ts == newTs);
+        assert(price == newPrice);
+
+        // but after an hour, we go to fallback
+        vm.warp(block.timestamp + 61);
+
+        vm.prank(address(l1Block));
+        gasPriceOracle.updateGasTokenPriceRatio();
+
+        (uint96 finalTs, uint160 finalPrice) = gasPriceOracle.getLatestPrice();
+        assert(finalTs == block.timestamp);
+        assert(finalPrice == 1_500_000e18);
+    }
+
+    function testTeaWAP_NonWETHOracleFails() public {
+        address notWeth = address(new OtherTokenNot());
+        MockOracle nonWethOracle = new MockOracle(notWeth, true);
+
+        vm.prank(Ownable(Predeploys.PROXY_ADMIN).owner());
+        vm.expectRevert();
+        gasPriceOracle.setOracleConfig(10, address(nonWethOracle));
+    }
+}

--- a/setup-devnet.sh
+++ b/setup-devnet.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+stop=$1
+
+if [ -n "$stop" ]; then
+  # https://github.com/moby/moby/issues/36196
+  make devnet-down \
+    && make devnet-clean \
+    && docker image rm $(docker image ls --filter "reference=us-docker.pkg.dev/oplabs-tools-artifacts/images/*:devnet" -q) \
+    && docker volume rm $(docker volume ls -q)
+else
+  # Set memory limits for Python process
+  export NODE_OPTIONS="--max-old-space-size=8192"
+
+  docker build -t my-tea-geth ../tea-geth \
+    && make devnet-up \
+    && docker logs -f ops-bedrock-l2-1
+fi


### PR DESCRIPTION
This is an alternate implementation of the gas price oracle mechanism.

Instead of performing the computation on the EVM, we simply store the TEA/ETH price ratio each epoch. This price is can be read straight from the statedb in op-geth, and used to adjust the L1 Data Cost.