### PR TITLE
Audit Fixes

### DIFF
--- a/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
+++ b/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
@@ -59,7 +59,7 @@ contract GasPriceOracle is TeaWAPOracle, ISemver {
     /// @notice Computes the L1 portion of the fee based on the size of the rlp encoded input
     ///         transaction, the current L1 base fee, and the various dynamic parameters.
     /// @param _data Unsigned fully RLP-encoded transaction to get the L1 fee for.
-        /// @dev This has been adapted to return the value in TEA rather than ETH.
+    /// @dev This has been adapted to return the value in TEA rather than ETH.
     /// @return L1 fee that should be paid for the tx
     function getL1Fee(bytes memory _data) external view returns (uint256) {
         (, uint160 latestPrice) = getLatestPrice();
@@ -72,7 +72,7 @@ contract GasPriceOracle is TeaWAPOracle, ISemver {
     }
 
     /// @notice Pulls the latest price from the oracle and updates the ratio storage slot.
-    /// @dev This function CAN NOT revert, as it is called by the System TX when updating L1Block.sol.
+    /// @dev This function MUST NOT revert, as it is called by the System TX when updating L1Block.sol.
     function updateGasTokenPriceRatio() external {
         require(msg.sender == Predeploys.L1_BLOCK_ATTRIBUTES, "GasPriceOracle: only L1_BLOCK_ATTRIBUTES can update");
 

--- a/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
+++ b/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
@@ -86,7 +86,7 @@ contract GasPriceOracle is TeaWAPOracle, ISemver {
             // If the call returned the fallback price, it failed.
             emit OracleReturnedFallbackPrice();
 
-            // If the last result is from within the past `maxDowntime`, keep it.
+            // If the last result is from within the past 5 minutes, keep it.
             // Otherwise, replace it with currentPrice (fallback)
             (uint96 lastUpdate, uint160 lastPrice) = getLatestPrice();
             if (currentPrice != lastPrice) {

--- a/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
+++ b/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
@@ -77,20 +77,20 @@ contract GasPriceOracle is TeaWAPOracle, ISemver {
         require(msg.sender == Predeploys.L1_BLOCK_ATTRIBUTES, "GasPriceOracle: only L1_BLOCK_ATTRIBUTES can update");
 
         // The oracle calculates the current price of 1e18 ETH in TEA (18 decimals).
-        uint160 currentPrice = teaPerETH();
+        (bool validPrice, uint160 currentPrice) = teaPerETH();
 
         // If the call didn't return the fallback price, it succeeded.
-        if (currentPrice != getFallbackPrice()) {
+        if (validPrice) {
             _setLatestPrice(currentPrice);
         } else {
             // If the call returned the fallback price, it failed.
             emit OracleReturnedFallbackPrice();
 
-            // If the last result is from within the past 1 hour, keep it.
+            // If the last result is from within the past `maxDowntime`, keep it.
             // Otherwise, replace it with currentPrice (fallback)
             (uint96 lastUpdate, uint160 lastPrice) = getLatestPrice();
             if (currentPrice != lastPrice) {
-                if (block.timestamp >= lastUpdate + MAX_ORACLE_DOWNTIME) {
+                if (block.timestamp > lastUpdate + MAX_ORACLE_DOWNTIME) {
                     _setLatestPrice(currentPrice);
                 }
             }

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -116,7 +116,7 @@ contract TeaWAPOracle {
 
         // Price is in 1e9 because that was the quote requested.
         // Multiply by 1e9 to convert to 18 decimals (making sure no overflow).
-        oldPrice = price;
+        uint256 oldPrice = price;
         unchecked { price = price * 1e9; }
         if (price < oldPrice) return (false, fallbackPrice);
 

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -215,8 +215,8 @@ contract TeaWAPOracle {
     function getOracleConfig() public view returns (address, uint16, uint80, bool, address) {
         uint256 data = Storage.getUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT);
 
-        uint16 twapObservations = uint8(data >> 240);
-        uint80 minWethBalance = uint72(data >> 160);
+        uint16 twapObservations = uint16(data >> 240);
+        uint80 minWethBalance = uint80(data >> 160);
         address oracle = address(uint160(data));
 
         data = Storage.getUint(WETH_ADDRESS_SLOT);

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -12,7 +12,7 @@ contract TeaWAPOracle {
     ////////////////////////////////
 
     /// @notice The storage slot that contains data about the TWAP oracle
-    /// @dev  uint8(twapObservations) | uint16(maxDowntime) | uint72(minWethAmount) | address(oracle)
+    /// @dev  uint16(twapObservations) | uint80(minWethAmount) | address(oracle)
     bytes32 public constant CUSTOM_GAS_TOKEN_ORACLE_SLOT = bytes32(uint256(keccak256("tea.customgastoken.oracle")) - 1);
 
     /// @notice The storage slot for the WETH address and its token position in the oracle

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -11,38 +11,34 @@ contract TeaWAPOracle {
     /////// STORAGE & EVENTS ///////
     ////////////////////////////////
 
-    /// @notice The storage slot that contains data about the TWAP
-    /// @dev  uint96(twapObservations) | address(oracle)
-    bytes32 public constant CUSTOM_GAS_TOKEN_ORACLE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.oracle")) - 1);
+    /// @notice The storage slot that contains data about the TWAP oracle
+    /// @dev  uint8(twapObservations) | uint16(maxDowntime) | uint72(minWethAmount) | address(oracle)
+    bytes32 public constant CUSTOM_GAS_TOKEN_ORACLE_SLOT = bytes32(uint256(keccak256("tea.customgastoken.oracle")) - 1);
 
     /// @notice The storage slot for the WETH address and its token position in the oracle
     /// @dev bool(token0?) | address(WETH)
-    bytes32 public constant WETH_ADDRESS_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.weth")) - 1);
+    bytes32 public constant WETH_ADDRESS_SLOT = bytes32(uint256(keccak256("tea.customgastoken.weth")) - 1);
 
     /// @notice The storage slot for the latest price
     /// @dev uint96(latestTime) | uint160(latestPrice)
-    bytes32 public constant CUSTOM_GAS_TOKEN_PRICE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.price")) - 1);
+    bytes32 public constant CUSTOM_GAS_TOKEN_PRICE_SLOT = bytes32(uint256(keccak256("tea.customgastoken.price")) - 1);
 
     /// @notice The storage slot that contains the fallback price, set by admin
-    bytes32 public constant FALLBACK_PRICE_SLOT = bytes32(uint256(keccak256("opstack.customgastoken.fallbackprice")) - 1);
+    bytes32 public constant FALLBACK_PRICE_SLOT = bytes32(uint256(keccak256("tea.customgastoken.fallbackprice")) - 1);
 
     /// @notice A backup TEA/ETH ratio, in the case that the oracle is not set
     ///         and the fallback price is not set.
     uint160 public constant BACKUP_TEA_WEI_PER_ETH = 1_500_000e18;
 
-    /// @notice The minimum WETH balance of the pool needed for the oracle to be valid.
-    /// @dev If the pool has less than this balance, it may be too easy to manipulate.
-    uint256 public constant MIN_WETH_BALANCE = 1e18;
-
     /// @notice The maximum amount of time we will allow failed oracle calls before
     ///         setting the storage value to the fallback.
-    uint256 public constant MAX_ORACLE_DOWNTIME = 1 hours;
+    uint256 public constant MAX_ORACLE_DOWNTIME = 5 minutes;
 
     /// @notice Emitted when the price is updated
     event NewPriceSet(uint160 price);
 
     /// @notice Emitted when the oracle configuration is updated
-    event OracleConfigUpdated(uint96 twapObservations, address oracle);
+    event OracleConfigUpdated(uint16 twapObservations, uint80 minWethBalance, address oracle);
 
     /// @notice Emitted when the fallback price is updated
     event FallbackPriceUpdated(uint256 price);
@@ -54,17 +50,22 @@ contract TeaWAPOracle {
     /// @notice Convert the inputted amount of ETH (18 decimals) to $TEA
     /// @dev amount (18 decimals) * teaPerETH (18 decimals) / 1e18 = teaAmount (18 decimals)
     function convertETHToTea(uint256 amount) public view returns (uint256) {
-        return amount * teaPerETH() / 1e18;
+        (, uint160 rate) = teaPerETH();
+        return amount * rate / 1e18;
     }
 
     /// @notice Get the price of price of 1 Ether (1e18) in $TEA (18 decimals).
+    /// @return valid Returned a valid price from the oracle (ie false = fallback)
+    /// @return price The price of 1 Ether in $TEA (18 decimals)
     /// @dev If the oracle is not set, we will return fallback price (also in 18 decimals).
     /// @dev If the fallback price is also not set, we will return a hardcoded backup.
-    function teaPerETH() public view returns (uint160) {
+    /// @dev This function exists for L1 Data Cost calculations, and should not be trusted externally.
+    function teaPerETH() public view returns (bool, uint160) {
         // Load oracle config from storage.
         (
             address oracle,
-            uint96 twapObservations,
+            uint16 twapObservations,
+            uint80 minWethBalance,
             bool wethT0,
             address weth
         ) = getOracleConfig();
@@ -74,18 +75,28 @@ contract TeaWAPOracle {
         uint160 fallbackPrice = getFallbackPrice();
 
         // If there is no oracle set, return the fallback price.
-        if (oracle == address(0)) return fallbackPrice;
+        if (oracle == address(0)) return (false, fallbackPrice);
+
+        // If Velodrome is paused, return the fallback price.
+        (bool success, bytes memory returndata) = oracle.staticcall(abi.encodeWithSignature("factory()"));
+        if (!success || returndata.length != 32) return (false, fallbackPrice);
+        address factory = abi.decode(returndata, (address));
+
+        (success, returndata) = factory.staticcall(abi.encodeWithSignature("paused()"));
+        if (!success || returndata.length != 32) return (false, fallbackPrice);
+        bool paused = abi.decode(returndata, (bool));
+        if (paused) return (false, fallbackPrice);
 
         // If there is too little value in the pool, it may be manipulated.
-        (bool success, bytes memory returndata) = oracle.staticcall(
+        (success, returndata) = oracle.staticcall(
             abi.encodeWithSignature("getReserves()")
         );
-        if (!success || returndata.length != 96) return fallbackPrice;
+        if (!success || returndata.length != 96) return (false, fallbackPrice);
         (uint r0, uint r1,) = abi.decode(returndata, (uint, uint, uint));
 
         // Use WETH reserves for this reliability, because it's the more stable token price.
         uint256 wethReserves = wethT0 ? r0 : r1;
-        if (wethReserves < MIN_WETH_BALANCE) return fallbackPrice;
+        if (wethReserves < minWethBalance) return (false, fallbackPrice);
 
         // Call the oracle to get the time weighted price.
         // https://github.com/velodrome-finance/contracts/blob/main/contracts/Pool.sol
@@ -93,19 +104,23 @@ contract TeaWAPOracle {
         (success, returndata) = oracle.staticcall(
             abi.encodeWithSignature(
                 "quote(address,uint256,uint256)",
-                weth, 1e18, twapObservations
+                weth, 1e9, twapObservations
             )
         );
 
         // It will revert if we don't have sufficient data points saved.
-        if (!success || returndata.length < 32) return fallbackPrice;
+        if (!success || returndata.length < 32) return (false, fallbackPrice);
 
         // Return the price, or the fallback price if the price is out of range.
         uint256 price = abi.decode(returndata, (uint256));
+
+        // Price is in 1e9 because that was the quote requested.
+        // Multiply by 1e9 to convert to 18 decimals.
+        price = price * 1e9;
         if (price == 0 || price > type(uint160).max) {
-            return fallbackPrice;
+            return (false, fallbackPrice);
         }
-        return uint160(price);
+        return (true, uint160(price));
     }
 
     ////////////////////////////////
@@ -113,22 +128,29 @@ contract TeaWAPOracle {
     ////////////////////////////////
 
     /// @param _twapObservations Number of observations to ask from the oracle
+    /// @param _minWethBalance Minimum WETH balance of the pool needed for the oracle to be valid
     /// @param _oracle Address of the oracle contract to use
-    function setOracleConfig(uint96 _twapObservations, address _oracle) external  {
+    function setOracleConfig(
+        uint16 _twapObservations,
+        uint80 _minWethBalance,
+        address _oracle
+    ) external  {
         require(msg.sender == Ownable(Predeploys.PROXY_ADMIN).owner(), "TeaWAPOracle: admin only");
-        require(_oracle != address(0), "VelodromeOracle: zero address");
-        require(_twapObservations > 0, "VelodromeOracle: zero observations");
 
-        _setOracleConfig(_twapObservations, _oracle);
+        require(_oracle != address(0), "TeaWAPOracle: zero address");
+        require(_twapObservations > 0, "TeaWAPOracle: zero observations");
+        require(_minWethBalance > 0, "TeaWAPOracle: zero min WETH balance");
 
-        emit OracleConfigUpdated(_twapObservations, _oracle);
+        _setOracleConfig(_twapObservations, _minWethBalance, _oracle);
+
+        emit OracleConfigUpdated(_twapObservations, _minWethBalance, _oracle);
     }
 
     /// @param _price Fallback price to use if oracle fails
     /// @dev Price should be set in wei of $TEA per 18 decimals of ETH
     function setFallbackPrice(uint160 _price) external {
         require(msg.sender == Ownable(Predeploys.PROXY_ADMIN).owner(), "TeaWAPOracle: admin only");
-        require(_price > 0, "VelodromeOracle: zero price");
+        require(_price > 0, "TeaWAPOracle: zero fallback price");
 
         _setFallbackPrice(_price);
 
@@ -174,22 +196,28 @@ contract TeaWAPOracle {
 
     /// @return oracle The address of the oracle contract that is being used
     /// @return twapObservations The number of TWAP observations to use with the oracle
+    /// @return minWethBalance The minimum WETH balance of the pool needed for the oracle to be valid
     /// @return wethT0 Whether WETH is token0 in the oracle
     /// @return weth The address of the WETH token in the oracle
-    function getOracleConfig() public view returns (address, uint96, bool, address) {
+    function getOracleConfig() public view returns (address, uint16, uint80, bool, address) {
         uint256 data = Storage.getUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT);
 
-        uint96 twapObservations = uint96(data >> 160);
+        uint16 twapObservations = uint8(data >> 240);
+        uint80 minWethBalance = uint72(data >> 160);
         address oracle = address(uint160(data));
 
         data = Storage.getUint(WETH_ADDRESS_SLOT);
         address weth = address(uint160(data));
         bool wethT0 = data >> 160 == 1;
 
-        return (oracle, twapObservations, wethT0, weth);
+        return (oracle, twapObservations, minWethBalance, wethT0, weth);
     }
 
-    function _setOracleConfig(uint96 _twapObservations, address _oracle) internal {
+    function _setOracleConfig(
+        uint16 _twapObservations,
+        uint80 _minWethBalance,
+        address _oracle
+    ) internal {
         // These tokens should be WTEA and WETH.
         (address t0, address t1) = IVelodromePool(_oracle).tokens();
 
@@ -207,7 +235,9 @@ contract TeaWAPOracle {
         require(keccak256(bytesName) == keccak256(abi.encode("Wrapped Ether")));
 
         Storage.setUint(CUSTOM_GAS_TOKEN_ORACLE_SLOT,
-            uint256(_twapObservations) << 160 | uint160(_oracle)
+            uint256(_twapObservations) << 240 |
+            uint256(_minWethBalance) << 160 |
+            uint160(_oracle)
         );
 
         Storage.setUint(WETH_ADDRESS_SLOT,

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -34,6 +34,9 @@ contract TeaWAPOracle {
     ///         setting the storage value to the fallback.
     uint256 public constant MAX_ORACLE_DOWNTIME = 5 minutes;
 
+    /// @notice One billion (1e9), used for oracle calls and other calculations.
+    uint256 constant GWEI = 1e9;
+
     /// @notice Emitted when the price is updated
     event NewPriceSet(uint160 price);
 
@@ -106,7 +109,7 @@ contract TeaWAPOracle {
         (success, returndata) = oracle.staticcall(
             abi.encodeWithSignature(
                 "quote(address,uint256,uint256)",
-                weth, 1e9, twapObservations
+                weth, GWEI, twapObservations
             )
         );
 
@@ -116,15 +119,17 @@ contract TeaWAPOracle {
         // Return the price, or the fallback price if the price is out of range.
         uint256 price = abi.decode(returndata, (uint256));
         {
-            // Price is in 1e9 because that was the quote requested.
-            // Multiply by 1e9 to convert to 18 decimals (making sure no overflow).
-            uint256 oldPrice = price;
-            unchecked { price = price * 1e9; }
-            if (price < oldPrice) return (false, fallbackPrice);
+            // If the price is zero, return the fallback price.
+            if (price == 0) return (false, fallbackPrice);
 
-            if (price == 0 || price > type(uint160).max) {
-                return (false, fallbackPrice);
-            }
+            // Price is in GWEI because that was the quote requested.
+            // Multiply by GWEI to convert to 18 decimals (making sure no overflow).
+            uint256 oldPrice = price;
+            unchecked { price = price * GWEI; }
+            if (price / GWEI != oldPrice) return (false, fallbackPrice);
+
+            // If the new price is greater than the max uint160, return the fallback price.
+            if (price > type(uint160).max) return (false, fallbackPrice);
         }
 
 

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -115,11 +115,15 @@ contract TeaWAPOracle {
         uint256 price = abi.decode(returndata, (uint256));
 
         // Price is in 1e9 because that was the quote requested.
-        // Multiply by 1e9 to convert to 18 decimals.
-        price = price * 1e9;
+        // Multiply by 1e9 to convert to 18 decimals (making sure no overflow).
+        oldPrice = price;
+        unchecked { price = price * 1e9; }
+        if (price < oldPrice) return (false, fallbackPrice);
+
         if (price == 0 || price > type(uint160).max) {
             return (false, fallbackPrice);
         }
+
         return (true, uint160(price));
     }
 

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -79,13 +79,15 @@ contract TeaWAPOracle {
 
         // If Velodrome is paused, return the fallback price.
         (bool success, bytes memory returndata) = oracle.staticcall(abi.encodeWithSignature("factory()"));
-        if (!success || returndata.length != 32) return (false, fallbackPrice);
-        address factory = abi.decode(returndata, (address));
+        {
+            if (!success || returndata.length != 32) return (false, fallbackPrice);
+            address factory = abi.decode(returndata, (address));
 
-        (success, returndata) = factory.staticcall(abi.encodeWithSignature("paused()"));
-        if (!success || returndata.length != 32) return (false, fallbackPrice);
-        bool paused = abi.decode(returndata, (bool));
-        if (paused) return (false, fallbackPrice);
+            (success, returndata) = factory.staticcall(abi.encodeWithSignature("paused()"));
+            if (!success || returndata.length != 32) return (false, fallbackPrice);
+            bool paused = abi.decode(returndata, (bool));
+            if (paused) return (false, fallbackPrice);
+        }
 
         // If there is too little value in the pool, it may be manipulated.
         (success, returndata) = oracle.staticcall(
@@ -113,16 +115,18 @@ contract TeaWAPOracle {
 
         // Return the price, or the fallback price if the price is out of range.
         uint256 price = abi.decode(returndata, (uint256));
+        {
+            // Price is in 1e9 because that was the quote requested.
+            // Multiply by 1e9 to convert to 18 decimals (making sure no overflow).
+            uint256 oldPrice = price;
+            unchecked { price = price * 1e9; }
+            if (price < oldPrice) return (false, fallbackPrice);
 
-        // Price is in 1e9 because that was the quote requested.
-        // Multiply by 1e9 to convert to 18 decimals (making sure no overflow).
-        uint256 oldPrice = price;
-        unchecked { price = price * 1e9; }
-        if (price < oldPrice) return (false, fallbackPrice);
-
-        if (price == 0 || price > type(uint160).max) {
-            return (false, fallbackPrice);
+            if (price == 0 || price > type(uint160).max) {
+                return (false, fallbackPrice);
+            }
         }
+
 
         return (true, uint160(price));
     }

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -83,7 +83,7 @@ contract TeaWAPOracle {
             if (!success || returndata.length != 32) return (false, fallbackPrice);
             address factory = abi.decode(returndata, (address));
 
-            (success, returndata) = factory.staticcall(abi.encodeWithSignature("paused()"));
+            (success, returndata) = factory.staticcall(abi.encodeWithSignature("isPaused()"));
             if (!success || returndata.length != 32) return (false, fallbackPrice);
             bool paused = abi.decode(returndata, (bool));
             if (paused) return (false, fallbackPrice);

--- a/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
+++ b/packages/contracts-bedrock/src/L2/TeaWAPOracle.sol
@@ -24,6 +24,7 @@ contract TeaWAPOracle {
     bytes32 public constant CUSTOM_GAS_TOKEN_PRICE_SLOT = bytes32(uint256(keccak256("tea.customgastoken.price")) - 1);
 
     /// @notice The storage slot that contains the fallback price, set by admin
+    /// @dev This price is stored as a uint160 to align with the `latestPrice` in the previous slot
     bytes32 public constant FALLBACK_PRICE_SLOT = bytes32(uint256(keccak256("tea.customgastoken.fallbackprice")) - 1);
 
     /// @notice A backup TEA/ETH ratio, in the case that the oracle is not set
@@ -52,7 +53,7 @@ contract TeaWAPOracle {
 
     /// @notice Convert the inputted amount of ETH (18 decimals) to $TEA
     /// @dev amount (18 decimals) * teaPerETH (18 decimals) / 1e18 = teaAmount (18 decimals)
-    function convertETHToTea(uint256 amount) public view returns (uint256) {
+    function convertETHToTea(uint256 amount) external view returns (uint256) {
         (, uint160 rate) = teaPerETH();
         return amount * rate / 1e18;
     }
@@ -97,7 +98,7 @@ contract TeaWAPOracle {
             abi.encodeWithSignature("getReserves()")
         );
         if (!success || returndata.length != 96) return (false, fallbackPrice);
-        (uint r0, uint r1,) = abi.decode(returndata, (uint, uint, uint));
+        (uint256 r0, uint256 r1,) = abi.decode(returndata, (uint, uint, uint));
 
         // Use WETH reserves for this reliability, because it's the more stable token price.
         uint256 wethReserves = wethT0 ? r0 : r1;
@@ -147,7 +148,7 @@ contract TeaWAPOracle {
         uint16 _twapObservations,
         uint80 _minWethBalance,
         address _oracle
-    ) external  {
+    ) external {
         require(msg.sender == Ownable(Predeploys.PROXY_ADMIN).owner(), "TeaWAPOracle: admin only");
 
         require(_oracle != address(0), "TeaWAPOracle: zero address");

--- a/packages/contracts-bedrock/src/L2/interfaces/IGasPriceOracle.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/IGasPriceOracle.sol
@@ -26,8 +26,8 @@ interface IGasPriceOracle {
     function teaPerETH() external view returns (uint160);
     function getLatestPrice() external view returns (uint96, uint160);
     function getFallbackPrice() external view returns (uint160);
-    function getOracleConfig() external view returns (address,uint96,bool,address);
-    function setOracleConfig(uint96,address) external;
+    function getOracleConfig() external view returns (address,uint16,uint80,bool,address);
+    function setOracleConfig(uint16,uint80,address) external;
     function CUSTOM_GAS_TOKEN_ORACLE_SLOT() external view returns (bytes32);
     function WETH_ADDRESS_SLOT() external view returns (bytes32);
     function CUSTOM_GAS_TOKEN_PRICE_SLOT() external view returns (bytes32);

--- a/packages/contracts-bedrock/test/L2/TeaWAPOracle.t.sol
+++ b/packages/contracts-bedrock/test/L2/TeaWAPOracle.t.sol
@@ -34,11 +34,19 @@ contract MockOracle {
         else return (0, 1e17, 0);
     }
 
+    function factory() public view returns (address) {
+        return address(this);
+    }
+
+    function paused() public view returns (bool) {
+        return false;
+    }
+
     function tokens() public view returns (address, address) {
         return (Predeploys.WETH, otherToken);
     }
 
-    function quote(address token, uint256 amount, uint256) external view returns (uint256) {
+    function quote(address token, uint256 amount, uint256) external pure returns (uint256) {
         if (token == Predeploys.WETH) {
             return amount / 2_000_000;
         } else {
@@ -80,31 +88,32 @@ contract TeaWAPOracle_Test is CommonTest {
 
     function testTeaWAP_SetUpOracle() public {
         vm.prank(Ownable(Predeploys.PROXY_ADMIN).owner());
-        gasPriceOracle.setOracleConfig(10, address(oracle));
+        gasPriceOracle.setOracleConfig(10, 1e18, address(oracle));
 
-        (address oracle_, uint96 twapObservations, bool wethT0, address weth_) = gasPriceOracle.getOracleConfig();
+        (address oracle_, uint16 twapObservations, uint80 minWethBalance, bool wethT0, address weth_) = gasPriceOracle.getOracleConfig();
         assertEq(oracle_, address(oracle));
         assertEq(twapObservations, 10);
+        assertEq(minWethBalance, 1e18);
         assertFalse(wethT0);
         assertEq(weth_, myWeth);
     }
 
     function testTeaWAP_GetPriceFromOracle() public {
         vm.prank(Ownable(Predeploys.PROXY_ADMIN).owner());
-        gasPriceOracle.setOracleConfig(10, address(oracle));
+        gasPriceOracle.setOracleConfig(10, 1e18, address(oracle));
 
         vm.prank(address(l1Block));
         gasPriceOracle.updateGasTokenPriceRatio();
 
         (uint96 ts, uint160 price) = gasPriceOracle.getLatestPrice();
         assert(ts == block.timestamp);
-        assert(price == oracle.quote(myWeth, 1e18, 10));
+        assert(price == 1e9 * oracle.quote(myWeth, 1e9, 10));
     }
 
     function testTeaWAP_FallbackIfBadReserves() public {
         MockOracle badResevesOracle = new MockOracle(myWeth, false);
         vm.prank(Ownable(Predeploys.PROXY_ADMIN).owner());
-        gasPriceOracle.setOracleConfig(10, address(badResevesOracle));
+        gasPriceOracle.setOracleConfig(10, 1e18, address(badResevesOracle));
 
         vm.prank(address(l1Block));
         gasPriceOracle.updateGasTokenPriceRatio();
@@ -116,7 +125,7 @@ contract TeaWAPOracle_Test is CommonTest {
 
     function testTeaWAP_StalePriceRevertToFallback() public {
         vm.prank(Ownable(Predeploys.PROXY_ADMIN).owner());
-        gasPriceOracle.setOracleConfig(10, address(oracle));
+        gasPriceOracle.setOracleConfig(10, 1e18, address(oracle));
 
         vm.prank(address(l1Block));
         gasPriceOracle.updateGasTokenPriceRatio();
@@ -128,8 +137,8 @@ contract TeaWAPOracle_Test is CommonTest {
         // now let's break the oracle
         vm.etch(address(oracle), abi.encode(""));
 
-        // after 59 minutes, should still skip
-        vm.warp(block.timestamp + 59 minutes);
+        // after 5 minutes, should still skip
+        vm.warp(block.timestamp + 5 minutes);
 
         vm.prank(address(l1Block));
         gasPriceOracle.updateGasTokenPriceRatio();
@@ -138,8 +147,8 @@ contract TeaWAPOracle_Test is CommonTest {
         assert(ts == newTs);
         assert(price == newPrice);
 
-        // but after an hour, we go to fallback
-        vm.warp(block.timestamp + 61);
+        // but anything past 5 mins, we go to fallback
+        vm.warp(block.timestamp + 1);
 
         vm.prank(address(l1Block));
         gasPriceOracle.updateGasTokenPriceRatio();
@@ -155,6 +164,6 @@ contract TeaWAPOracle_Test is CommonTest {
 
         vm.prank(Ownable(Predeploys.PROXY_ADMIN).owner());
         vm.expectRevert();
-        gasPriceOracle.setOracleConfig(10, address(nonWethOracle));
+        gasPriceOracle.setOracleConfig(10, 1e18, address(nonWethOracle));
     }
 }


### PR DESCRIPTION
Price Applies Slippage
- Changed to 1e9 for the quote, and multiply by 1e9 after to get to 18 decimals.
- Perform the multiplication unchecked (with confirmation after) to avoid any risk of overflow revert.

Pool Paused
- Check to confirm oracle.factory().paused() is false (with proper error handling to avoid revert).

Manipulate Price Across Blocks
- This is really clearly invalid, would recommend you talk to someone who knows MEV and will be easy to verify. If you want to include no problem, but won't fix.

Fallback Price Check
- Return a bool with `teaPerETH()` that is used for fallback check rather than equivalent prices.

Governance Token
- Confirmed, TEA Governance will be on L2.

Sequencer Downtime
- Acknowledged, won't fix. Not too worried about a couple blocks where this is underpriced.

No TeaPerETH Integrations
- Added a @dev comment to make this clear.

Set Price Fallback Delay
- Decided to change the minimum from 1 hour to 5 minutes (and hardcode), so no longer worried.

TWAP Constants
- Changed `minWethBalance` to a variable. 
- Kept MAX_ORACLE_DOWNTIME as a constant, because can't imagine when we'd want to change that and not upgrade the contract.

Storage Namespace
- Changed.